### PR TITLE
Add report out of predicted vs. actual stat

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,12 @@ xdoctest magnet/example_random_predictor.py
 In this example, we ask the framework to generate some demo data for us (which will run HELM on the backend).  After the demo data has been generated, we instantiate the `ExampleRandomPredictor` allowing it 5 response samples from the evaluation data.  Then we run the random predictor against the generated demo data, which should produce a `"predicted_exact_match"` metric in the form of a HELM `Stat` object, i.e.:
 
 ```
-[{'name': 'predicted_exact_match', 'split': 'valid'}[min=0.82, mean=0.82, max=0.82, sum=0.82 (1)]]
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━┳━━━━━━━┳━━━━━━━┳━━━━━━━┳━━━━━━━━┳━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━┓
+┃ run_spec                                                               ┃ source    ┃ name        ┃ mean  ┃ min   ┃ max   ┃ count ┃ stddev ┃ sum   ┃ sum_squared ┃ variance ┃
+┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━━━━━╇━━━━━━━╇━━━━━━━╇━━━━━━━╇━━━━━━━╇━━━━━━━━╇━━━━━━━╇━━━━━━━━━━━━━╇━━━━━━━━━━┩
+│ mmlu:subject=philosophy,method=multiple_choice_joint,model=openai_gpt2 │ predicted │ exact_match │ 0.720 │ 0.720 │ 0.720 │ 1     │ 0.000  │ 0.720 │ 0.518       │ 0.000    │
+│ mmlu:subject=philosophy,method=multiple_choice_joint,model=openai_gpt2 │ actual    │ exact_match │ 0.000 │ 0.000 │ 0.000 │ 1     │ 0.000  │ 0.000 │ 0.000       │ 0.000    │
+└────────────────────────────────────────────────────────────────────────┴───────────┴─────────────┴───────┴───────┴───────┴───────┴────────┴───────┴─────────────┴──────────┘
 ```
 
 (Note that the exact values in your output may be different due to the random nature of this predictor)
@@ -80,8 +85,12 @@ Note that in this example, we request demo data of the `boolq` scenario with `da
 Expected output for this example is:
 
 ```
-[{'name': 'predicted_exact_match', 'split': 'valid', 'perturbation': {'name': 'misspellings', 'robustness': True, 'fairness': False, 'computed_on': 'perturbed', 'prob': 0.05}}[min=0.653, mean=0.653, max=0.653, sum=0.653 (1)]]
-
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━┳━━━━━━━┳━━━━━━━┳━━━━━━━┳━━━━━━━━┳━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━┓
+┃ run_spec                                               ┃ source    ┃ name        ┃ mean  ┃ min   ┃ max   ┃ count ┃ stddev ┃ sum   ┃ sum_squared ┃ variance ┃
+┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━━━━━╇━━━━━━━╇━━━━━━━╇━━━━━━━╇━━━━━━━╇━━━━━━━━╇━━━━━━━╇━━━━━━━━━━━━━╇━━━━━━━━━━┩
+│ boolq,data_augmentation=misspelling0:model=openai_gpt2 │ predicted │ exact_match │ 0.663 │ 0.663 │ 0.663 │ 1     │ 0.000  │ 0.663 │ 0.440       │ 0.000    │
+│ boolq,data_augmentation=misspelling0:model=openai_gpt2 │ actual    │ exact_match │ 0.650 │ 0.650 │ 0.650 │ 1     │ 0.000  │ 0.650 │ 0.423       │ 0.000    │
+└────────────────────────────────────────────────────────┴───────────┴─────────────┴───────┴───────┴───────┴───────┴────────┴───────┴─────────────┴──────────┘
 ```
 
 ## Running on local HELM outputs
@@ -115,7 +124,7 @@ class MyPredictor(Predictor):
                 train_scenario_states_df,
                 train_stats_df,
                 eval_run_specs_df,
-                eval_scenario_states_df) -> List[Stat]:
+                eval_scenario_states_df) -> dict[str, list[Stat]]:
         # Interesting prediction algorithm code goes here
 ```
 
@@ -124,17 +133,19 @@ instances).  For example, assume we're predicting the `"exact_match"`
 stat:
 
 ```
-return [Stat(**{'name': {'name': 'predicted_exact_match',
-                         'split': 'valid'},
-                'count': 1,
-                'sum': prediction,
-                'sum_squared': prediction ** 2,
-                'min': prediction,
-                'max': prediction,
-                'mean': prediction,
-                'variance': 0.0,
-                'stddev': 0.0})]
+return {run_spec_name: [Stat(**{'name': {'name': 'predicted_exact_match',
+                                         'split': 'valid'},
+                                'count': 1,
+                                'sum': prediction,
+                                'sum_squared': prediction ** 2,
+                                'min': prediction,
+                                'max': prediction,
+                                'mean': prediction,
+                                'variance': 0.0,
+                                'stddev': 0.0})]}
 ```
+
+**NOTE:** In order for the `Predictor` superclass to match the predicted stats with the actual stats from eval data, the `name.name` should be the same (apart from a `'predicted_'` prefix), and any other parameters under the `name` field should match as well.
 
 The arguments passed into the `predict` method are Pandas dataframes corresponding to the HELM data (flattened from it's nested form) for the relevant runs.  We've included an IPython notebook file here ([predict_inputs_exploration.ipynb](./predict_inputs_exploration.ipynb)) showing the exact form of the inputs to `predict`.
 
@@ -142,7 +153,6 @@ We also recommend looking at the `magnet/example_random_predictor.py` and/or `ma
 
 # Roadmap
 
-- Comparison results of predicted vs. actual metric
 - More options for predict input (dataframes vs. HELM objects vs. dicts)
 - Support for non-prediction style TA1 algorithms (feedback needed)
 - Expose model weights for a given run

--- a/magnet/example_perturbation_predictor.py
+++ b/magnet/example_perturbation_predictor.py
@@ -25,8 +25,8 @@ class ExamplePerturbationPredictor(Predictor):
                 train_scenario_states_df,
                 train_stats_df,
                 eval_run_specs_df,
-                eval_scenario_states_df) -> List[Stat]:
-        predicted_stats = []
+                eval_scenario_states_df) -> dict[str, list[Stat]]:
+        predicted_stats = {}
 
         perturbed_exact_match_stats_df = train_stats_df[
             (train_stats_df['stats.name.name'] == 'exact_match') &
@@ -53,7 +53,7 @@ class ExamplePerturbationPredictor(Predictor):
             # `model.predict` outputs a 2d numpy array, need to unpack the single value
             prediction = prediction[0][0]
 
-            predicted_stats.append(
+            predicted_stats.setdefault(row['run_spec.name'], []).append(
                 Stat(**{'name':
                         {'name': 'predicted_exact_match',
                          'split': 'valid',

--- a/magnet/example_random_predictor.py
+++ b/magnet/example_random_predictor.py
@@ -23,12 +23,13 @@ class ExampleRandomPredictor(Predictor):
                 train_scenario_state_df,
                 train_stats_df,
                 eval_run_specs_df,
-                eval_scenario_state_df) -> List[Stat]:
-        predicted_stats = []
+                eval_scenario_state_df) -> dict[str, list[Stat]]:
+        predicted_stats = {}
 
-        for run_spec in eval_scenario_state_df.groupby(['run_spec.name']):
+        for key, _ in eval_scenario_state_df.groupby(['run_spec.name']):
+            run_spec_name, = key
             prediction = (random.choice(range(0,101)) / 100)
-            predicted_stats.append(
+            predicted_stats.setdefault(run_spec_name, []).append(
                 Stat(**{'name':
                         {'name': 'predicted_exact_match',
                          'split': 'valid'},


### PR DESCRIPTION
The implementation here ended up being pretty unsavory and I'm certain there's a cleaner / nicer way to do this.  However the point here is that we've updated the output format for predictors to be a dictionary of the type `dict[str, list[Stat]]` (vs. previously `list[Stat]`) to establish the relationship between the eval run and the predicted stats.  As well as there now being some kind of useful output on the command line when you run a predictor, e.g. (from the perturbation doctest example):

```
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━┳━━━━━━━┳━━━━━━━┳━━━━━━━┳━━━━━━━━┳━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━┓
┃ run_spec                                               ┃ source    ┃ name        ┃ mean  ┃ min   ┃ max   ┃ count ┃ stddev ┃ sum   ┃ sum_squared ┃ variance ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━━━━━╇━━━━━━━╇━━━━━━━╇━━━━━━━╇━━━━━━━╇━━━━━━━━╇━━━━━━━╇━━━━━━━━━━━━━╇━━━━━━━━━━┩
│ boolq,data_augmentation=misspelling0:model=openai_gpt2 │ predicted │ exact_match │ 0.663 │ 0.663 │ 0.663 │ 1     │ 0.000  │ 0.663 │ 0.440       │ 0.000    │
│ boolq,data_augmentation=misspelling0:model=openai_gpt2 │ actual    │ exact_match │ 0.650 │ 0.650 │ 0.650 │ 1     │ 0.000  │ 0.650 │ 0.423       │ 0.000    │
└────────────────────────────────────────────────────────┴───────────┴─────────────┴───────┴───────┴───────┴───────┴────────┴───────┴─────────────┴──────────┘

```