### PR TITLE
Add dockerfiles

### DIFF
--- a/dockerfiles/README.md
+++ b/dockerfiles/README.md
@@ -1,0 +1,89 @@
+# AIQ-MAGNET Container Build
+
+This repo contains two Dockerfiles:
+
+- `uv.dockerfile` — a fast, reproducible **Python + uv** base (GPU-ready by default).
+- `magnet.dockerfile` — a **generic app image** that inherits from the `uv` base and installs the repo code.
+
+The goal is to keep the Python/uv/tooling layer stable and cached, while allowing frequent app changes.
+
+---
+
+## 1) Build the `uv` base image
+
+Choose your Python and uv versions using build args (defaults are defined in `uv.dockerfile`). Example:
+
+```bash
+# Tag variables (edit to taste)
+# Choose versions
+export IMAGE_NAME=uv
+export UV_VERSION=0.8.4
+export PYTHON_VERSION=3.13
+export BASE_IMAGE=nvidia/cuda:12.9.1-cudnn-devel-ubuntu24.04
+export BASE_TAG=$(echo "$BASE_IMAGE" | sed "s#.*/##; s/://g")
+export UV_IMAGE_TAG=${UV_VERSION}-python${PYTHON_VERSION}-$BASE_TAG
+export UV_IMAGE_QUALNAME=$IMAGE_NAME:$UV_IMAGE_TAG
+
+echo "UV_IMAGE_QUALNAME=$UV_IMAGE_QUALNAME"
+
+# Build the uv base image
+DOCKER_BUILDKIT=1 docker build --progress=plain \
+  -t "$UV_IMAGE_QUALNAME" \
+  --build-arg UV_VERSION=$UV_VERSION \
+  --build-arg PYTHON_VERSION=$PYTHON_VERSION \
+  --build-arg BASE_IMAGE=$BASE_IMAGE \
+  --build-arg VCS_REF=$(git rev-parse HEAD) \
+  --build-arg REPO_URL=$(git config --get remote.origin.url | sed 's/\.git$//') \
+  --build-arg DOCKERFILE_PATH=uv.dockerfile \
+  -f dockerfiles/uv.dockerfile .
+```
+
+**Smoke test the base:**
+
+```bash
+docker run --rm -it $UV_IMAGE_QUALNAME uv --version
+docker run --rm -it $UV_IMAGE_QUALNAME python -V
+# GPU (optional):
+docker run --rm --gpus=all -it $UV_IMAGE_QUALNAME nvidia-smi
+```
+
+Note: A variant of this image is prebuild on https://hub.docker.com/repository/docker/erotemic/uv/general
+
+---
+
+## 2) Build the app image (`magnet.dockerfile`)
+
+
+```bash
+# --- Build the magnet app image using the uv tag ---
+# Build against a specific git version
+export GIT_REF=$(git rev-parse --short=12 HEAD)
+
+export MAGNET_IMAGE_NAME=magnet
+export UV_BASE_IMAGE=uv:$UV_IMAGE_TAG # exact uv base
+export MAGNET_IMAGE_TAG=$GIT_REF-uv$UV_IMAGE_TAG # inherit uv tag
+export MAGNET_IMAGE_QUALNAME=$MAGNET_IMAGE_NAME:$MAGNET_IMAGE_TAG
+
+DOCKER_BUILDKIT=1 docker build --progress=plain \
+  -t "$MAGNET_IMAGE_QUALNAME" \
+  --build-arg UV_BASE="$UV_IMAGE_QUALNAME" \
+  --build-arg GIT_REF="$GIT_REF" \
+  -f dockerfiles/magnet.dockerfile .
+
+# Helpful aliases
+docker tag "$MAGNET_IMAGE_QUALNAME" $MAGNET_IMAGE_NAME:latest
+docker tag "$MAGNET_IMAGE_QUALNAME" $MAGNET_IMAGE_NAME:latest-python${PYTHON_VERSION}
+```
+
+**Smoke test the repo:**
+
+```bash
+docker run --rm -it $MAGNET_IMAGE_QUALNAME bash -lc 'python -V && uv --version'
+docker run --rm --gpus=all -it $MAGNET_IMAGE_QUALNAME nvidia-smi   # optional
+```
+
+
+**Run unit tests** 
+```bash
+docker run --rm -it $MAGNET_IMAGE_QUALNAME pytest
+```

--- a/dockerfiles/magnet.dockerfile
+++ b/dockerfiles/magnet.dockerfile
@@ -1,0 +1,66 @@
+# syntax=docker/dockerfile:1.6
+# See tail for quickbuild instructions.
+ARG UV_BASE=uv:latest
+FROM ${UV_BASE}
+
+# ---------------------------------
+# Step 5: Checkout and install REPO
+# ---------------------------------
+# Based on the state of the repo this copies the host .git data over and then
+# checks out the exact version requested by GIT_REF. It then performs a basic
+# install of the project into the virtual environment.
+
+ENV REPO_DNAME=aiq-magnet
+RUN mkdir -p /root/code/$REPO_DNAME
+WORKDIR /root/code/${REPO_DNAME}
+
+# Copy only the git metadata; the checkout will materialize the tree
+COPY .git /root/code/${REPO_DNAME}/.git
+
+# Control the version/commit to checkout (default: current branch tip)
+ARG GIT_REF=HEAD
+
+# Faster editable installs with uv; avoid modifying system site-packages
+ENV UV_LINK_MODE=copy
+
+RUN --mount=type=cache,target=/root/.cache <<'EOF'
+set -e
+
+cd  /root/code/${REPO_DNAME}
+
+# Checkout the requested branch 
+git checkout "$GIT_REF"
+git reset --hard "$GIT_REF"
+
+# First install pinned requirements for reproducibility
+uv pip install -r requirements.lock.txt
+
+# Install the repo in development mode
+uv pip install -e .[tests] 
+
+EOF
+
+# Default workdir to the repo
+WORKDIR /root/code/${REPO_DNAME}
+
+# See README.md for full usage instructions.
+
+
+################
+### __DOCS__ ###
+################
+RUN <<EOF
+echo '
+# Local-only app image that layers on the uv base image.
+# Build the base first (tagged as uv:latest), then build this image.
+
+# navigate to the magnet repo
+cd $HOME/code/aiq-magnet
+
+docker build -f dockerfiles/uv.dockerfile -t uv:latest .
+docker build -f dockerfiles/magnet.dockerfile -t magnet:latest .
+
+
+' > /dev/null
+EOF
+

--- a/dockerfiles/uv.dockerfile
+++ b/dockerfiles/uv.dockerfile
@@ -1,0 +1,241 @@
+# syntax=docker/dockerfile:1.5
+
+# Defined in: https://gitlab.kitware.com/computer-vision/ci-docker/-/blob/main/uv.dockerfile
+
+# Allow overriding the base image at build time
+# Base should be a compatible ubuntu image.
+# Other available tags: https://hub.docker.com/r/nvidia/cuda/tags
+ARG BASE_IMAGE=nvidia/cuda:12.4.1-cudnn-devel-ubuntu22.04
+FROM ${BASE_IMAGE} AS base
+
+# ------------------------------------
+# Step 1: Install System Prerequisites
+# ------------------------------------
+
+RUN --mount=type=cache,target=/var/cache/apt \
+    --mount=type=cache,target=/var/lib/apt/lists <<EOF
+#!/bin/bash
+set -e
+apt update -q
+DEBIAN_FRONTEND=noninteractive apt install -q -y --no-install-recommends \
+    curl \
+    wget \
+    git \
+    unzip \
+    ca-certificates \
+    build-essential 
+# Note: normal image cleanup not needed with buildkit cache
+EOF
+
+
+# Note: the above apt command contains some nice to have extras for developer
+# images, we can likely exclude these in a future optimized version.
+
+
+# Set the shell to bash to auto-activate enviornments
+SHELL ["/bin/bash", "-l", "-c"]
+
+# ------------------
+# Step 2: Install uv
+# ------------------
+# Here we take a few extra steps to pin to a verified version of the uv
+# installer. This increases reproducibility and security against the main
+# astral domain, but not against those linked in the main installer.
+# The "normal" way to install the latest uv is:
+# curl -LsSf https://astral.sh/uv/install.sh | bash
+
+# Control the version of uv
+ARG UV_VERSION=0.8.8
+
+RUN --mount=type=cache,target=/root/.cache <<EOF
+#!/bin/bash
+set -e
+mkdir /bootstrap
+cd /bootstrap
+# For new releases see: https://github.com/astral-sh/uv/releases
+declare -A UV_INSTALL_KNOWN_HASHES=(
+    ["0.8.8"]="f86123768d4602c5de570fe2e43d3ef0720e907d420aec8c663da81e41c8de57"
+    ["0.8.4"]="601321180a10e0187c99d8a15baa5ccc11b03494c2ca1152fc06f5afeba0a460"
+    ["0.7.20"]="3b7ca115ec2269966c22201b3a82a47227473bef2fe7066c62ea29603234f921"
+    ["0.7.19"]="e636668977200d1733263a99d5ea66f39d4b463e324bb655522c8782d85a8861"
+)
+EXPECTED_SHA256="${UV_INSTALL_KNOWN_HASHES[${UV_VERSION}]}"
+DOWNLOAD_PATH=uv-install-v${UV_VERSION}.sh
+if [[ -z "$EXPECTED_SHA256" ]]; then
+    echo "No hash known for UV_VERSION '$UV_VERSION'; version does not exist or hash entry is missing from internal table. Aborting."
+    exit 1
+fi
+curl -LsSf https://astral.sh/uv/$UV_VERSION/install.sh > $DOWNLOAD_PATH
+report_bad_checksum(){
+    echo "Got unexpected checksum"
+    sha256sum "$DOWNLOAD_PATH"
+    exit 1
+}
+echo "$EXPECTED_SHA256  $DOWNLOAD_PATH" | sha256sum --check || report_bad_checksum
+# Run the install script
+bash /bootstrap/uv-install-v${UV_VERSION}.sh
+EOF
+
+
+# ------------------------------------------
+# Step 3: Setup a Python virtual environment
+# ------------------------------------------
+# This step mirrors a normal virtualenv development environment inside the
+# container, which can prevent subtle issues due when running as root inside
+# containers. 
+
+# Control which python version we are using
+ARG PYTHON_VERSION=3.13
+
+ENV PIP_ROOT_USER_ACTION=ignore
+
+RUN --mount=type=cache,target=/root/.cache <<EOF
+#!/bin/bash
+export PATH="$HOME/.local/bin:$PATH"
+# Use uv to install the requested python version and seed the venv
+uv venv "/root/venv$PYTHON_VERSION" --python=$PYTHON_VERSION --seed
+BASHRC_CONTENTS='
+# setup a user-like environment, even though we are root
+export HOME="/root"
+export PATH="$HOME/.local/bin:$PATH"
+# Auto-activate the venv on login
+source $HOME/venv'$PYTHON_VERSION'/bin/activate
+'
+# It is important to add the content to both so 
+# subsequent run commands use the context we setup here.
+echo "$BASHRC_CONTENTS" >> $HOME/.bashrc
+echo "$BASHRC_CONTENTS" >> $HOME/.profile
+echo "$BASHRC_CONTENTS" >> $HOME/.bash_profile
+EOF
+
+# -----------------------------------
+# Step 4: Ensure venv auto-activation
+# -----------------------------------
+# This step creates an entrypoint script that ensures any command passed to
+# `docker run` is executed inside a login shell where the virtual environment
+# is auto-activated. It handles complex cases like multi-arg commands and
+# ensures quoting is preserved accurately.
+RUN <<EOF
+#!/bin/bash
+set -e
+
+# We use a quoted heredoc to write the entrypoint script literally, with no variable expansion.
+cat <<'__EOSCRIPT__' > /entrypoint.sh
+#!/bin/bash
+set -e
+
+# Reconstruct the full command line safely, quoting each argument
+args=()
+for arg in "$@"; do
+  args+=("$(printf "%q" "$arg")")
+done
+
+# Join arguments into a command string that can be executed by bash -c
+# This preserves exact argument semantics (including quotes, spaces, etc.)
+cmd="${args[*]}"
+
+# Execute the reconstructed command inside a login shell
+# This ensures virtualenv activation via .bash_profile
+exec bash -l -c "$cmd"
+__EOSCRIPT__
+
+# Print the script at build time for visibility/debugging
+cat /entrypoint.sh
+
+chmod +x /entrypoint.sh
+EOF
+
+
+# Set the entrypoint to our script that activates the virtual environment first
+ENTRYPOINT ["/entrypoint.sh"]
+
+# Set the default workdir to the user home directory
+WORKDIR /root
+
+# Increase startup speed of images:
+# https://docs.astral.sh/uv/reference/cli/#uv-run--compile-bytecode
+ENV UV_COMPILE_BYTECODE=1
+
+ARG VCS_REF=""
+ARG REPO_URL=""
+ARG DOCKERFILE_PATH=""
+
+LABEL org.opencontainers.image.title="uv Python" \
+      org.opencontainers.image.description="uv ${UV_VERSION} and Python ${PYTHON_VERSION} in an auto-activating virtual environment with base image: ${BASE_IMAGE}." \
+      org.opencontainers.image.url="$REPO_URL/-/blob/$VCS_REF/$DOCKERFILE_PATH" \
+      org.opencontainers.image.source="$REPO_URL" \
+      org.opencontainers.image.revision="$VCS_REF" \
+      org.opencontainers.image.version="uv${UV_VERSION}-python${PYTHON_VERSION}" \
+      org.opencontainers.image.licenses="Apache-2.0" \
+      org.opencontainers.image.authors="Jon Crall <jon.crall@kitware.com>, Kitware Inc." \
+      org.opencontainers.image.vendor="Kitware Inc." 
+
+#ARG CREATED=""
+# Note sure if we really want a created tag as it messes with hashes
+# Keep created layer separate
+#LABEL org.opencontainers.image.created="$CREATED"
+
+
+################
+### __DOCS__ ###
+################
+RUN <<EOF
+echo '
+# https://www.docker.com/blog/introduction-to-heredocs-in-dockerfiles/
+
+cd ~/code/ci-docker
+
+# Build the image with version-specific tags
+export IMAGE_NAME=uv
+export UV_VERSION=0.8.8
+export PYTHON_VERSION=3.11
+export BASE_IMAGE=nvidia/cuda:12.4.1-cudnn-devel-ubuntu22.04
+export BASE_TAG=$(echo "$BASE_IMAGE" | sed "s#.*/##; s/://g")
+export IMAGE_TAG=${UV_VERSION}-python${PYTHON_VERSION}-$BASE_TAG
+export IMAGE_QUALNAME=$IMAGE_NAME:$IMAGE_TAG
+
+echo "IMAGE_QUALNAME=$IMAGE_QUALNAME"
+
+DOCKER_BUILDKIT=1 docker build --progress=plain \
+    -t "$IMAGE_QUALNAME" \
+    --build-arg UV_VERSION=$UV_VERSION \
+    --build-arg PYTHON_VERSION=$PYTHON_VERSION \
+    --build-arg BASE_IMAGE=$BASE_IMAGE \
+    -f uv.dockerfile .
+
+# Test the build
+test_build(){
+    docker run --gpus=all -it $IMAGE_QUALNAME nvidia-smi
+    docker run --gpus=all -it $IMAGE_QUALNAME echo "hello" "world"
+    docker run --gpus=all -it $IMAGE_QUALNAME du -sh /root/.cache
+    #docker run --gpus=all -it $IMAGE_QUALNAME bash
+}
+
+# Inspect the build
+inspect_build(){
+    docker image history $IMAGE_QUALNAME --no-trunc
+    docker image history $IMAGE_QUALNAME
+    docker image inspect $IMAGE_QUALNAME
+}
+
+# Add concise tags for easier reuse
+export ALIAS1=$IMAGE_NAME:latest
+export ALIAS2=$IMAGE_NAME:latest-python${PYTHON_VERSION}
+docker tag $IMAGE_QUALNAME $ALIAS1
+docker tag $IMAGE_QUALNAME $ALIAS2
+
+# Push to dockerhub
+export REMOTE_NAME="erotemic"
+
+# 3) Create remote-qualified tags
+docker tag $IMAGE_QUALNAME $REMOTE_NAME/$IMAGE_QUALNAME
+docker tag $ALIAS1  $REMOTE_NAME/$ALIAS1
+docker tag $ALIAS2  $REMOTE_NAME/$ALIAS2
+
+# 4) Push the tags
+docker push $REMOTE_NAME/$IMAGE_QUALNAME
+docker push $REMOTE_NAME/$ALIAS1
+docker push $REMOTE_NAME/$ALIAS2
+
+' > /dev/null
+EOF


### PR DESCRIPTION
@dmjoy 

Quick and dirty initial docker files. I did have an issue with the nvidia smoke tests, but pytest ran just fine.

This is based on a uv base image I've been working on in: https://gitlab.kitware.com/computer-vision/ci-docker

which I also have uploaded to: https://hub.docker.com/repository/docker/erotemic/uv/general

There is a small change here, in that my ci-docker variant installs a few more helper apt packages, which I did removed to make this more minimal. 

This keeps the magnet.dockerfile fairly simple. Copy in the .git folder, checkout a specific hash, install in development mode. There is a quickbuild heredoc at the end of the file, and much more in depth instruction in the README that give you fine-grained control over the version the base image, uv, and python. 