### PR TITLE
Add "HELMInferenceEngine"

### DIFF
--- a/magnet/__init__.py
+++ b/magnet/__init__.py
@@ -6,6 +6,7 @@ __autogen__ = (
 # Manually declare what should be exposed when regenerating with mkinit
 __submodules__ = {
     'helm_outputs': ['HelmOutputs'],
+    'helm_inference': ['HelmInferenceEngine'],
     'example_random_predictor': [],
     'demo': [],
     'loaders': [],
@@ -32,8 +33,11 @@ __getattr__, __dir__, __all__ = lazy_loader.attach(
         'helm_outputs': [
             'HelmOutputs',
         ],
+        'helm_inference': [
+            'HelmInferenceEngine',
+        ],
     },
 )
 
-__all__ = ['HelmOutputs', 'demo', 'example_random_predictor', 'helm_outputs',
+__all__ = ['HelmOutputs', 'HelmInferenceEngine', 'demo', 'example_random_predictor', 'helm_outputs',
            'loaders', 'predictor', 'utils']

--- a/magnet/helm_inference.py
+++ b/magnet/helm_inference.py
@@ -37,6 +37,35 @@ class HelmInferenceEngine:
         >>> response = replace(response, request_time=None, request_datetime=None)
         >>> print(response)
         RequestResult(success=True, embedding=[], completions=[GeneratedOutput(text='\\n\\nThe answer is yes. The moon is', logprob=0.0, tokens=[Token(text='\\n', logprob=0.0), Token(text='\\n', logprob=0.0), Token(text='The', logprob=0.0), Token(text=' answer', logprob=0.0), Token(text=' is', logprob=0.0), Token(text=' yes', logprob=0.0), Token(text='.', logprob=0.0), Token(text=' The', logprob=0.0), Token(text=' moon', logprob=0.0), Token(text=' is', logprob=0.0)], finish_reason=None, multimodal_content=None, thinking=None)], cached=False, request_time=None, request_datetime=None, error=None, error_flags=None, batch_size=None, batch_request_time=None)
+        >>> model = self.get_loaded_model('openai/gpt2')
+        >>> print(model)
+        GPT2LMHeadModel(
+          (transformer): GPT2Model(
+            (wte): Embedding(50257, 768)
+            (wpe): Embedding(1024, 768)
+            (drop): Dropout(p=0.1, inplace=False)
+            (h): ModuleList(
+              (0-11): 12 x GPT2Block(
+                (ln_1): LayerNorm((768,), eps=1e-05, elementwise_affine=True)
+                (attn): GPT2Attention(
+                  (c_attn): Conv1D(nf=2304, nx=768)
+                  (c_proj): Conv1D(nf=768, nx=768)
+                  (attn_dropout): Dropout(p=0.1, inplace=False)
+                  (resid_dropout): Dropout(p=0.1, inplace=False)
+                )
+                (ln_2): LayerNorm((768,), eps=1e-05, elementwise_affine=True)
+                (mlp): GPT2MLP(
+                  (c_fc): Conv1D(nf=3072, nx=768)
+                  (c_proj): Conv1D(nf=768, nx=3072)
+                  (act): NewGELUActivation()
+                  (dropout): Dropout(p=0.1, inplace=False)
+                )
+              )
+            )
+            (ln_f): LayerNorm((768,), eps=1e-05, elementwise_affine=True)
+          )
+          (lm_head): Linear(in_features=768, out_features=50257, bias=False)
+        )
     """
 
     def __init__(self, execution_spec=None):

--- a/magnet/helm_inference.py
+++ b/magnet/helm_inference.py
@@ -14,7 +14,7 @@ from helm.clients.huggingface_client import HuggingFaceServerFactory
 
 
 class HelmInferenceEngine:
-    """
+    r"""
     Class allowing model inference requests through HELM.
 
     NOTE ** The responses generated here are not captured on disk as
@@ -36,33 +36,12 @@ class HelmInferenceEngine:
         >>> response = self.inference_request(request)
         >>> response = replace(response, request_time=None, request_datetime=None)
         >>> print(response)
-        RequestResult(success=True, embedding=[], completions=[GeneratedOutput(text='\\n\\nThe answer is yes. The moon is', logprob=0.0, tokens=[Token(text='\\n', logprob=0.0), Token(text='\\n', logprob=0.0), Token(text='The', logprob=0.0), Token(text=' answer', logprob=0.0), Token(text=' is', logprob=0.0), Token(text=' yes', logprob=0.0), Token(text='.', logprob=0.0), Token(text=' The', logprob=0.0), Token(text=' moon', logprob=0.0), Token(text=' is', logprob=0.0)], finish_reason=None, multimodal_content=None, thinking=None)], cached=False, request_time=None, request_datetime=None, error=None, error_flags=None, batch_size=None, batch_request_time=None)
+        RequestResult(success=True, embedding=[], completions=[GeneratedOutput(text='\n\nThe answer is yes. The moon is', logprob=0.0, tokens=...
         >>> model = self.get_loaded_model('openai/gpt2')
         >>> print(model)
         GPT2LMHeadModel(
           (transformer): GPT2Model(
-            (wte): Embedding(50257, 768)
-            (wpe): Embedding(1024, 768)
-            (drop): Dropout(p=0.1, inplace=False)
-            (h): ModuleList(
-              (0-11): 12 x GPT2Block(
-                (ln_1): LayerNorm((768,), eps=1e-05, elementwise_affine=True)
-                (attn): GPT2Attention(
-                  (c_attn): Conv1D(nf=2304, nx=768)
-                  (c_proj): Conv1D(nf=768, nx=768)
-                  (attn_dropout): Dropout(p=0.1, inplace=False)
-                  (resid_dropout): Dropout(p=0.1, inplace=False)
-                )
-                (ln_2): LayerNorm((768,), eps=1e-05, elementwise_affine=True)
-                (mlp): GPT2MLP(
-                  (c_fc): Conv1D(nf=3072, nx=768)
-                  (c_proj): Conv1D(nf=768, nx=3072)
-                  (act): NewGELUActivation()
-                  (dropout): Dropout(p=0.1, inplace=False)
-                )
-              )
-            )
-            (ln_f): LayerNorm((768,), eps=1e-05, elementwise_affine=True)
+          ...
           )
           (lm_head): Linear(in_features=768, out_features=50257, bias=False)
         )

--- a/magnet/helm_inference.py
+++ b/magnet/helm_inference.py
@@ -1,0 +1,52 @@
+from helm.common.request import Request
+from helm.common.request import RequestResult, GeneratedOutput
+from helm.common.authentication import Authentication
+from helm.benchmark.executor import ExecutionSpec, Executor, ExecutorError
+from helm.benchmark.config_registry import (
+    # register_configs_from_directory,
+    register_builtin_configs_from_helm_package,
+)
+from helm.common.hierarchical_logger import hwarn
+
+
+class HELMInferenceEngine:
+    def __init__(self, execution_spec=None):
+        # Not sure this is the best place to do this, or if it's
+        # idempotent
+        register_builtin_configs_from_helm_package()
+
+        if execution_spec is None:
+            auth = Authentication("")
+            url = None
+            local_path = "prod_env"
+            num_threads = 1
+            dry_run = False
+            sqlite_cache_backend_config = None
+            mongo_cache_backend_config = None
+
+            execution_spec = ExecutionSpec(
+                auth=auth,
+                url=url,
+                local_path=local_path,
+                parallelism=num_threads,
+                dry_run=dry_run,
+                sqlite_cache_backend_config=sqlite_cache_backend_config,
+                mongo_cache_backend_config=mongo_cache_backend_config)
+
+        self.executor = Executor(execution_spec)
+
+    def inference_request(self, request: Request) -> RequestResult:
+        # Largely copied (with a few tweaks to remove the RequestState
+        # container) from the Executor.process method in HELM (
+        # https://github.com/stanford-crfm/helm/blob/v0.5.8/src/helm/benchmark/executor.py#L111)
+        try:
+            result: RequestResult = self.executor.context.make_request(request)
+        except Exception as e:
+            raise ExecutorError(f"{str(e)} Request: {request}") from e
+        if not result.success:
+            if result.error_flags and not result.error_flags.is_fatal:
+                hwarn(f"Non-fatal error treated as empty completion: {result.error}")
+                result.completions = [GeneratedOutput(text="", logprob=0, tokens=[])]
+            else:
+                raise ExecutorError(f"{str(result.error)} Request: {request}")
+        return result

--- a/magnet/helm_inference.py
+++ b/magnet/helm_inference.py
@@ -7,6 +7,7 @@ from helm.benchmark.config_registry import (
     register_builtin_configs_from_helm_package,
 )
 from helm.common.hierarchical_logger import hwarn
+from helm.clients.huggingface_client import HuggingFaceServerFactory
 
 
 class HELMInferenceEngine:
@@ -50,3 +51,12 @@ class HELMInferenceEngine:
             else:
                 raise ExecutorError(f"{str(result.error)} Request: {request}")
         return result
+
+    @staticmethod
+    def get_loaded_model(model_name):
+        server = HuggingFaceServerFactory._servers.get(model_name)
+
+        if server is not None:
+            return server.model
+        else:
+            return None


### PR DESCRIPTION
Adding a a small component here for one-off inference requests.  I still need to add some example/docstring here (also thinking that at some point a "recipes" document would be a good idea to help the TA1s along).

EDIT: Since the `inference_request` method requires a `Request` object (and there are a handful of fields in there that most folks probably won't care to tinker with, but shouldn't change), my recommendation is to do something like:
```
from dataclasses import replace

# original_request is a HELM "Request" dataclass object
my_request = replace(original_request, prompt="My new prompt", temperature=0.7, num_completions=10)
```
