### PR TITLE
Fix pyproject scripts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,9 +39,6 @@ dependencies = [
     "pyyaml>=6.0.2",
 ]
 
-[project.scripts]
-magnet-helm-run = "magnet.backends.helm.magnet_run_helm:main"
-
 [project.optional-dependencies]
 
 tests = [
@@ -62,6 +59,7 @@ all = [
 
 [project.scripts]
 magnet = "magnet.__main__:main"
+magnet-helm-run = "magnet.backends.helm.magnet_run_helm:main"
 
 [tool.pytest.ini_options]
 addopts = "--xdoctest --xdoctest-style=google --ignore-glob=docs"


### PR DESCRIPTION
Latest merge introduced a duplicate key in the TOML, fixing that. 