### PR TITLE
Dev/claim aggregation output

### DIFF
--- a/magnet/evaluation.py
+++ b/magnet/evaluation.py
@@ -644,9 +644,10 @@ def _reduce_results(results, reduce_spec):
         if threshold is None:
             raise ValueError("reduce type=fraction requires `threshold`")
         frac = verified_count / total
-        print(f'[reduce=fraction] VERIFIED {verified_count}/{total} ({frac:.3f}) vs threshold {threshold}')
+        final_result = 'VERIFIED' if frac >= threshold else 'FALSIFIED'
+        print(f'[reduce=fraction] {final_result} {verified_count}/{total} ({frac:.3f}) vs threshold {threshold}')
         print()
-        return 'VERIFIED' if frac >= threshold else 'FALSIFIED'
+        return final_result
 
     raise ValueError(f"Unknown reduce type: {rtype!r}")
 

--- a/magnet/evaluation.py
+++ b/magnet/evaluation.py
@@ -228,17 +228,37 @@ class EvaluationCard:
             )
 
         # Claim Resolution
-        results = []
+        #
+        # Optional parallelism:
+        #   MAGNET_EVAL_N_JOBS=N         int, default 1 (serial, backward-compatible)
+        #   MAGNET_EVAL_BACKEND=<name>   joblib backend: loky (default), threading,
+        #                                multiprocessing. loky is robust on macOS;
+        #                                threading shares module-level caches but
+        #                                only helps for GIL-releasing workloads.
+        import os as _os
+        _n_jobs = int(_os.environ.get('MAGNET_EVAL_N_JOBS', '1'))
+        _backend = _os.environ.get('MAGNET_EVAL_BACKEND', 'loky')
 
-        for evaluation in self.evaluations:
+        def _run_one(evaluation):
             status, _ = evaluation.execute()
-            results.append(status)
-
             results_fpath = (
                 claim_results_path / evaluation._execution_hash / 'verdict.json'
             )
             results_fpath.parent.ensuredir()
             results_fpath.write_text(json.dumps(evaluation.log, indent=2))
+            return status, results_fpath
+
+        if _n_jobs == 1:
+            out = [_run_one(e) for e in self.evaluations]
+        else:
+            from joblib import Parallel, delayed
+            out = Parallel(n_jobs=_n_jobs, backend=_backend, verbose=5)(
+                delayed(_run_one)(e) for e in self.evaluations
+            )
+
+        results = []
+        for status, results_fpath in out:
+            results.append(status)
             print(f'Wrote claim output to {results_fpath}')
 
         total = len(results)
@@ -258,13 +278,7 @@ class EvaluationCard:
         print('================================')
         print('\n')
 
-        card_result = ''
-        if falsified_count:
-            card_result = 'FALSIFIED'
-        elif inconclusive_count:
-            card_result = 'INCONCLUSIVE'
-        else:
-            card_result = 'VERIFIED'
+        card_result = _reduce_results(results, self.claim.reduce)
 
         self.claim.status = card_result
         return card_result
@@ -574,6 +588,48 @@ class EvaluationTask:
         return ub.hash_data(self.symbols.simple_view())[:12]
 
 
+def _reduce_results(results, reduce_spec):
+    """
+    Reduce per-sweep-point claim outcomes to a single card-level status.
+
+    reduce_spec: dict with key `type`:
+      - {'type': 'all'}    (default)  any FALSIFIED -> FALSIFIED; any INCONCLUSIVE -> INCONCLUSIVE; else VERIFIED
+      - {'type': 'any'}               any VERIFIED -> VERIFIED; any INCONCLUSIVE (and no VERIFIED) -> INCONCLUSIVE; else FALSIFIED
+      - {'type': 'fraction', 'threshold': 0.8}
+                                      VERIFIED_count / total >= threshold -> VERIFIED; else FALSIFIED.
+                                      INCONCLUSIVE points count in the denominator but not the numerator.
+    """
+    total = len(results)
+    if total == 0:
+        return 'INCONCLUSIVE'
+
+    verified_count    = results.count('VERIFIED')
+    falsified_count   = results.count('FALSIFIED')
+    inconclusive_count = results.count('INCONCLUSIVE')
+
+    rtype = reduce_spec.get('type', 'all')
+    if rtype == 'all':
+        if falsified_count:
+            return 'FALSIFIED'
+        if inconclusive_count:
+            return 'INCONCLUSIVE'
+        return 'VERIFIED'
+    if rtype == 'any':
+        if verified_count:
+            return 'VERIFIED'
+        if inconclusive_count:
+            return 'INCONCLUSIVE'
+        return 'FALSIFIED'
+    if rtype == 'fraction':
+        threshold = reduce_spec.get('threshold')
+        if threshold is None:
+            raise ValueError("reduce type=fraction requires `threshold`")
+        frac = verified_count / total
+        print(f'[reduce=fraction] VERIFIED {verified_count}/{total} ({frac:.3f}) vs threshold {threshold}')
+        return 'VERIFIED' if frac >= threshold else 'FALSIFIED'
+    raise ValueError(f"Unknown reduce type: {rtype!r}")
+
+
 class Claim:
     """
     Represents a verifiable assertion for a set of resolved symbols
@@ -598,6 +654,7 @@ class Claim:
 
     def __init__(self, raw):
         self.claim = raw.get('python')
+        self.reduce = raw.get('reduce', {'type': 'all'})
         self.status = 'UNVERIFIED'
 
     def evaluate(self, symbols: Dict[str, Any] = {}):
@@ -616,6 +673,7 @@ class Claim:
             out_msg = ''
             exec(self.claim, symbols)
             self.status = 'VERIFIED'
+            out_msg = 'Assertion holds'
         except AssertionError as e:
             self.status = 'FALSIFIED'
             out_msg = f'Assertion does not hold: {e}'

--- a/magnet/evaluation.py
+++ b/magnet/evaluation.py
@@ -67,6 +67,18 @@ class EvaluationConfig(scfg.DataConfig):
     )
 
 
+# Claim Resolution (pulled out as standalone function for
+# multiprocessing support)
+def _run_one(evaluation, claim_results_path):
+    status, _ = evaluation.execute()
+    results_fpath = (
+        claim_results_path / evaluation._execution_hash / 'verdict.json'
+    )
+    results_fpath.parent.ensuredir()
+    results_fpath.write_text(json.dumps(evaluation.log, indent=2))
+    return status, results_fpath
+
+
 class EvaluationCard:
     """
     Specification of an empirical claim with resolvable symbols and metadata
@@ -248,22 +260,12 @@ class EvaluationCard:
                 Symbols.decompose_symbol_defs(self.symbols)
             )
 
-        # Claim Resolution
-        def _run_one(evaluation):
-            status, _ = evaluation.execute()
-            results_fpath = (
-                claim_results_path / evaluation._execution_hash / 'verdict.json'
-            )
-            results_fpath.parent.ensuredir()
-            results_fpath.write_text(json.dumps(evaluation.log, indent=2))
-            return status, results_fpath
-
         if jobs == 1:
-            out = [_run_one(e) for e in self.evaluations]
+            out = [_run_one(e, claim_results_path) for e in self.evaluations]
         else:
             from joblib import Parallel, delayed
             out = Parallel(n_jobs=jobs, backend=parallel_backend, verbose=5)(
-                delayed(_run_one)(e) for e in self.evaluations
+                delayed(_run_one)(e, claim_results_path) for e in self.evaluations
             )
 
         results = []

--- a/magnet/evaluation.py
+++ b/magnet/evaluation.py
@@ -14,7 +14,9 @@ from kwdagger import Pipeline, ProcessNode
 from kwdagger.schedule import ScheduleEvaluationConfig, build_schedule
 from loguru import logger
 from rich import print
+import safer
 
+SAFER_USE_TEMPFILE = not ub.WIN32
 
 DEFAULT_CLAIM_AGGREGATION_STRATEGY = {'type': 'all'}
 
@@ -75,7 +77,11 @@ def _run_one(evaluation, claim_results_path):
         claim_results_path / evaluation._execution_hash / 'verdict.json'
     )
     results_fpath.parent.ensuredir()
-    results_fpath.write_text(json.dumps(evaluation.log, indent=2))
+
+    with safer.open(results_fpath, 'w', temp_file=SAFER_USE_TEMPFILE) as f:
+        json.dump(evaluation.log, f, indent=2, ensure_ascii=False)
+        f.write('\n')
+
     return status, results_fpath
 
 
@@ -222,7 +228,7 @@ class EvaluationCard:
         card_output_path = self.output_path / self._run_hash
         card_output_path.ensuredir()
 
-        with open(card_output_path / 'card.yaml', 'w') as f:
+        with safer.open(card_output_path / 'card.yaml', 'w', temp_file=SAFER_USE_TEMPFILE) as f:
             yaml.safe_dump(self.original_card, f, sort_keys=False)
 
         claim_results_path = card_output_path / 'results'
@@ -295,8 +301,9 @@ class EvaluationCard:
                              'claim_aggregation_strategy': self.claim_aggregation_strategy,
                              'claims': [e._execution_hash for e in self.evaluations]}
 
-        with open(card_output_path / 'verdict.json', 'w') as f:
-            json.dump(aggregate_verdict, f, indent=2)
+        with safer.open(card_output_path / 'verdict.json', 'w', temp_file=SAFER_USE_TEMPFILE) as f:
+            json.dump(aggregate_verdict, f, indent=2, ensure_ascii=False)
+            f.write('\n')
 
         self.claim.status = card_result
         return card_result

--- a/magnet/evaluation.py
+++ b/magnet/evaluation.py
@@ -16,6 +16,9 @@ from loguru import logger
 from rich import print
 
 
+DEFAULT_CLAIM_AGGREGATION_STRATEGY = {'type': 'all'}
+
+
 class EvaluationConfig(scfg.DataConfig):
     """
     Resolve an Evaluation Card
@@ -45,6 +48,22 @@ class EvaluationConfig(scfg.DataConfig):
         None,
         type=str,
         help='Override symbol values (e.g. --override dataset: legalbench\nnum_replicates: 5)',
+    )
+
+    jobs = scfg.Value(
+        1,
+        type=int,
+        help=(
+            'Number of evaluation jobs. Use 1 for serial execution, '
+            '-1 for all available CPUs when using joblib.'
+        ),
+    )
+
+    parallel_backend = scfg.Value(
+        'loky',
+        type=str,
+        choices=['loky', 'threading', 'multiprocessing'],
+        help='Joblib backend used when --jobs is not 1.',
     )
 
 
@@ -113,6 +132,8 @@ class EvaluationCard:
         self.description = cfg.get('description', '')
 
         self.claim = Claim(cfg.get('claim'))
+        self.claim_aggregation_strategy = cfg.get(
+            'claim_aggregation_strategy', DEFAULT_CLAIM_AGGREGATION_STRATEGY)
         self.symbols = cfg.get('symbols', {})
 
         # explicit kwdagger spec
@@ -165,7 +186,7 @@ class EvaluationCard:
                 else:
                     self.symbols[key]['sweep'] = [value]
 
-    def evaluate(self):
+    def evaluate(self, jobs=1, parallel_backend='loky'):
         """
         Run the evaluation specification
 
@@ -228,17 +249,6 @@ class EvaluationCard:
             )
 
         # Claim Resolution
-        #
-        # Optional parallelism:
-        #   MAGNET_EVAL_N_JOBS=N         int, default 1 (serial, backward-compatible)
-        #   MAGNET_EVAL_BACKEND=<name>   joblib backend: loky (default), threading,
-        #                                multiprocessing. loky is robust on macOS;
-        #                                threading shares module-level caches but
-        #                                only helps for GIL-releasing workloads.
-        import os as _os
-        _n_jobs = int(_os.environ.get('MAGNET_EVAL_N_JOBS', '1'))
-        _backend = _os.environ.get('MAGNET_EVAL_BACKEND', 'loky')
-
         def _run_one(evaluation):
             status, _ = evaluation.execute()
             results_fpath = (
@@ -248,11 +258,11 @@ class EvaluationCard:
             results_fpath.write_text(json.dumps(evaluation.log, indent=2))
             return status, results_fpath
 
-        if _n_jobs == 1:
+        if jobs == 1:
             out = [_run_one(e) for e in self.evaluations]
         else:
             from joblib import Parallel, delayed
-            out = Parallel(n_jobs=_n_jobs, backend=_backend, verbose=5)(
+            out = Parallel(n_jobs=jobs, backend=parallel_backend, verbose=5)(
                 delayed(_run_one)(e) for e in self.evaluations
             )
 
@@ -278,7 +288,13 @@ class EvaluationCard:
         print('================================')
         print('\n')
 
-        card_result = _reduce_results(results, self.claim.reduce)
+        card_result = _reduce_results(results, self.claim_aggregation_strategy)
+        aggregate_verdict = {'result': card_result,
+                             'claim_aggregation_strategy': self.claim_aggregation_strategy,
+                             'claims': [e._execution_hash for e in self.evaluations]}
+
+        with open(card_output_path / 'verdict.json', 'w') as f:
+            json.dump(aggregate_verdict, f, indent=2)
 
         self.claim.status = card_result
         return card_result
@@ -593,9 +609,9 @@ def _reduce_results(results, reduce_spec):
     Reduce per-sweep-point claim outcomes to a single card-level status.
 
     reduce_spec: dict with key `type`:
-      - {'type': 'all'}    (default)  any FALSIFIED -> FALSIFIED; any INCONCLUSIVE -> INCONCLUSIVE; else VERIFIED
+      - {'type': 'all'}               any FALSIFIED -> FALSIFIED; any INCONCLUSIVE -> INCONCLUSIVE; else VERIFIED
       - {'type': 'any'}               any VERIFIED -> VERIFIED; any INCONCLUSIVE (and no VERIFIED) -> INCONCLUSIVE; else FALSIFIED
-      - {'type': 'fraction', 'threshold': 0.8}
+      - {'type': 'fraction', 'parameters': {'threshold': 0.8}}
                                       VERIFIED_count / total >= threshold -> VERIFIED; else FALSIFIED.
                                       INCONCLUSIVE points count in the denominator but not the numerator.
     """
@@ -621,12 +637,15 @@ def _reduce_results(results, reduce_spec):
             return 'INCONCLUSIVE'
         return 'FALSIFIED'
     if rtype == 'fraction':
-        threshold = reduce_spec.get('threshold')
+        parameters = reduce_spec.get('parameters', {})
+        threshold = parameters.get('threshold')
         if threshold is None:
             raise ValueError("reduce type=fraction requires `threshold`")
         frac = verified_count / total
         print(f'[reduce=fraction] VERIFIED {verified_count}/{total} ({frac:.3f}) vs threshold {threshold}')
+        print()
         return 'VERIFIED' if frac >= threshold else 'FALSIFIED'
+
     raise ValueError(f"Unknown reduce type: {rtype!r}")
 
 
@@ -654,7 +673,6 @@ class Claim:
 
     def __init__(self, raw):
         self.claim = raw.get('python')
-        self.reduce = raw.get('reduce', {'type': 'all'})
         self.status = 'UNVERIFIED'
 
     def evaluate(self, symbols: Dict[str, Any] = {}):
@@ -887,7 +905,7 @@ def main(argv=None, **kwargs):
     if args.override is not None:
         card.replace(args.override)
 
-    card.evaluate()
+    card.evaluate(jobs=args.jobs, parallel_backend=args.parallel_backend)
     card.summarize()
 
 


### PR DESCRIPTION
This PR adds support for an aggregate claim output file (`verdict.json`); and includes parallel processing support and claim "reduction" (named `claim_aggregation_strategy` for now).  Thanks @bkj for the initial work on this (https://github.com/AIQ-Kitware/aiq-magnet/pull/51).

One important difference here coming from the original implementation is that I've renamed `reduce` to `claim_aggregation_strategy` and bumped it up a level in the card.  To test, I modified the `llama.yaml` card example in this repo with (claim is the same, just including it here for context):
```
claim_aggregation_strategy:
  type: fraction
  parameters:
    threshold: 0.6

claim:
  python: |
    assert abs(comp_score - base_score) < threshold, f"{comp_model} score ({comp_score:.2f}) exceeds consistency bound on {base_model} ({base_score:.2f})"
```