### PR TITLE
Misc tweaks / fixes

### DIFF
--- a/magnet/evaluation.py
+++ b/magnet/evaluation.py
@@ -356,7 +356,7 @@ class EvaluationCard:
                 )
                 for metric, value in calculated_metrics.items():
                     metric_statement += f'  {metric}: {value: .3f}\n'
-                print(metric_statement[:-1])
+                logger.info(metric_statement[:-1])
 
         total = len(results)
 
@@ -1031,7 +1031,7 @@ class Metric:
         self.reducer = reducer
 
     def aggregate_calculate(self, runs: List[float]) -> MetricValue:
-        print(f'Computing {self.name} Metric across all runs\n')
+        logger.info(f'Computing {self.name} Metric across all runs\n')
         return self.reducer(runs)
 
     @classmethod

--- a/magnet/predictor.py
+++ b/magnet/predictor.py
@@ -1,4 +1,5 @@
 from typing import Any
+from enum import StrEnum, auto
 
 import rich
 from rich.markup import escape
@@ -10,17 +11,21 @@ from loguru import logger
 from magnet.backends.helm.helm_outputs import HelmRuns, HelmSuites
 from magnet.data_splits import TestSplit, TrainSplit
 
+class Policy(StrEnum):
+    ERROR = auto()
+    WARN = auto()
+    IGNORE = auto()
 
 class Predictor:
     def __init__(self,
                  num_example_runs=3,
                  num_eval_samples=20,
                  random_seed=1,
-                 raise_error_on_insufficient_eval_samples=False):
+                 insufficient_eval_sample_policy=Policy.WARN):
         self.num_example_runs = num_example_runs
         self.num_eval_samples = num_eval_samples
         self.random_seed = random_seed
-        self.raise_error_on_insufficient_eval_samples = raise_error_on_insufficient_eval_samples
+        self.insufficient_eval_sample_policy = insufficient_eval_sample_policy
 
     def run_spec_filter(self, run_spec):
         # To be overridden; likely only want to use this filter *OR*
@@ -87,10 +92,14 @@ class Predictor:
         _full_eval_per_instance_stats_df = _all_per_instance_stats_df[_all_per_instance_stats_df['run_spec.name'] == eval_run]
 
         if self.num_eval_samples > len(_full_eval_scenario_state_df):
-            if self.raise_error_on_insufficient_eval_samples:
+            if self.insufficient_eval_sample_policy == Policy.ERROR:
                 raise RuntimeError("Not enough rows in eval scenario_state to sample")
-            else:
+            elif self.insufficient_eval_sample_policy == Policy.WARN:
                 logger.warning("Not enough rows in eval_scenario_state to sample")
+            elif self.insufficient_eval_sample_policy == Policy.IGNORE:
+                pass
+            else:
+                raise ValueError("Unknown insufficient_eval_sample_policy")
 
         # Sample up to `self.num_eval_samples` random instances from
         # scenario_states

--- a/magnet/predictor.py
+++ b/magnet/predictor.py
@@ -5,6 +5,7 @@ from rich.markup import escape
 import ubelt as ub
 import pandas as pd
 import kwarray
+from loguru import logger
 
 from magnet.backends.helm.helm_outputs import HelmRuns, HelmSuites
 from magnet.data_splits import TestSplit, TrainSplit
@@ -14,10 +15,12 @@ class Predictor:
     def __init__(self,
                  num_example_runs=3,
                  num_eval_samples=20,
-                 random_seed=1):
+                 random_seed=1,
+                 raise_error_on_insufficient_eval_samples=False):
         self.num_example_runs = num_example_runs
         self.num_eval_samples = num_eval_samples
         self.random_seed = random_seed
+        self.raise_error_on_insufficient_eval_samples = raise_error_on_insufficient_eval_samples
 
     def run_spec_filter(self, run_spec):
         # To be overridden; likely only want to use this filter *OR*
@@ -84,7 +87,10 @@ class Predictor:
         _full_eval_per_instance_stats_df = _all_per_instance_stats_df[_all_per_instance_stats_df['run_spec.name'] == eval_run]
 
         if self.num_eval_samples > len(_full_eval_scenario_state_df):
-            raise RuntimeError("Not enough rows in eval scenario_state to sample")
+            if self.raise_error_on_insufficient_eval_samples:
+                raise RuntimeError("Not enough rows in eval scenario_state to sample")
+            else:
+                logger.warning("Not enough rows in eval_scenario_state to sample")
 
         # Sample up to `self.num_eval_samples` random instances from
         # scenario_states
@@ -260,7 +266,7 @@ class RunPredictor(Predictor):
         # More human readable float
         rounded_human_table = human_table.round(3)
 
-        rich.print(escape(rounded_human_table.to_string()))
+        logger.info(escape(rounded_human_table.to_string()))
 
         return human_table
 


### PR DESCRIPTION
* Downgraded the insufficient eval instance samples error in the `predictor.py` to a warning (but can revert back to previous behavior by setting the `raise_error_on_insufficient_eval_samples` init variable to `True`)
** This has been a feature request from some of the TA1 teams
* Replaced some print statements with `logger` calls instead