### PR TITLE
Dev/theory to card

### DIFF
--- a/magnet/theory/__init__.py
+++ b/magnet/theory/__init__.py
@@ -58,8 +58,18 @@ Teams annotating their own code do not need MAGNET installed:
 :mod:`magnet.theory.shim` is a dependency-free file to vendor, in which every
 predicate is a no-op.
 """
-from magnet.theory.basis import AssumptionCoverage, CoverageReport, TheoreticalBasis
-from magnet.theory.index import hygiene, load, load_index, load_manifest, save_index
+from magnet.theory.basis import (
+    AssumptionCoverage,
+    CoverageReport,
+    TheoreticalBasis,
+)
+from magnet.theory.index import (
+    hygiene,
+    load,
+    load_index,
+    load_manifest,
+    save_index,
+)
 from magnet.theory.model import (
     KERNEL_AXIOMS,
     Check,

--- a/magnet/theory/__init__.py
+++ b/magnet/theory/__init__.py
@@ -1,0 +1,136 @@
+"""
+Connecting formalized theory to empirical evaluation.
+
+MAGNET's premise is that it "connects theoretical claims about AI model
+generalization to empirical validation through standardized evaluation cards".
+This package is the connection.
+
+A card measures a claim. Sometimes that claim is the finite-sample shadow of a
+statement that has been proved -- in Lean, from a paper, about an idealized
+version of the same setup. The statement holds *provided a list of explicit
+hypotheses*; the experiment almost never satisfies them literally. Each way it
+departs is an **edge**, declared at the code that departs:
+
+.. code:: python
+
+    from magnet.theory import approximates, assumes, grounds, substitutes
+
+    @substitutes('Paper.main::yNN', kind='estimator-swap',
+                 informal='ordinary least squares, not the nearest-neighbour '
+                          'estimator the theorem covers')
+    def predict(self, train, test): ...
+
+    @approximates('Paper.main::hcover',
+                  informal='fixed reference pool; the theorem needs density')
+    def __init__(self, num_example_runs=64): ...
+
+    assumes('Paper.main::hlipschitz', severity='high',
+            informal='score smoothness in embedding distance is never tested')
+
+    @grounds('Paper.TheoryPractice.EmpiricalCrossBudgetMAEClaim')
+    def claim(results):
+        assert results['candidate_mae'] <= results['baseline_mae']
+
+Which yields, next to the verdict:
+
+.. code:: text
+
+    RESULT:  VERIFIED
+    BASIS:   standing on 6 assumptions: 1 discharged, 4 relaxed (max severity
+             high), 1 unaccounted
+
+Three things about the design are worth knowing before using it.
+
+**The verb carries the relation.** ``satisfies``, ``approximates``,
+``substitutes``, ``assumes``, ``ignores``, ``violates`` -- and ``checks``, which
+resolves at run time. Each reads as a true sentence at the site it annotates.
+
+**Every predicate activates three ways** -- bare call, decorator, context
+manager -- with identical registration, so the ledger never depends on a code
+path being reached. See :mod:`magnet.theory.predicates`.
+
+**Annotations are read from source, not from imports.**
+:mod:`magnet.theory.static` extracts the ledger by parsing, so a repository can
+be audited without installing its dependencies or executing its code. The
+runtime registry is for evidence -- what actually ran, with what values.
+
+Teams annotating their own code do not need MAGNET installed:
+:mod:`magnet.theory.shim` is a dependency-free file to vendor, in which every
+predicate is a no-op.
+"""
+from magnet.theory.basis import AssumptionCoverage, CoverageReport, TheoreticalBasis
+from magnet.theory.index import hygiene, load, load_index, load_manifest, save_index
+from magnet.theory.model import (
+    KERNEL_AXIOMS,
+    Check,
+    CodeSite,
+    Formalization,
+    Freshness,
+    Hypothesis,
+    HypothesisRef,
+    Observation,
+    ProofStatus,
+    Relation,
+    ReviewStatus,
+    Severity,
+    Theorem,
+    parse_ref,
+)
+from magnet.theory.predicates import (
+    PREDICATE_NAMES,
+    Edge,
+    Grounding,
+    approximates,
+    assumes,
+    checks,
+    grounds,
+    ignores,
+    satisfies,
+    substitutes,
+    violates,
+)
+from magnet.theory.registry import REGISTRY, TheoryRegistry
+
+__all__ = [
+    # predicates
+    'satisfies',
+    'approximates',
+    'substitutes',
+    'assumes',
+    'ignores',
+    'violates',
+    'checks',
+    'grounds',
+    # annotation objects
+    'Edge',
+    'Grounding',
+    'PREDICATE_NAMES',
+    # model
+    'Formalization',
+    'Theorem',
+    'Hypothesis',
+    'HypothesisRef',
+    'CodeSite',
+    'Observation',
+    'Check',
+    'Relation',
+    'Severity',
+    'ProofStatus',
+    'ReviewStatus',
+    'Freshness',
+    'KERNEL_AXIOMS',
+    'parse_ref',
+    # assembly
+    'TheoreticalBasis',
+    'CoverageReport',
+    'AssumptionCoverage',
+    # registry
+    'REGISTRY',
+    'TheoryRegistry',
+    # loading
+    'load',
+    'hygiene',
+    'load_index',
+    'load_manifest',
+    'save_index',
+]

--- a/magnet/theory/audit.py
+++ b/magnet/theory/audit.py
@@ -17,27 +17,27 @@ CommandLine:
 """
 import sys
 
-import scriptconfig as scfg
+import kwconf
 import ubelt as ub
 
 __all__ = ['TheoryAuditCLI', 'audit']
 
 
-class TheoryAuditCLI(scfg.DataConfig):
+class TheoryAuditCLI(kwconf.Config):
     """
     Report what a codebase assumes, and what proves it.
     """
 
     __command__ = 'audit'
 
-    source = scfg.Value(
+    source: list[str] = kwconf.Value(
         '.',
         position=1,
         nargs='+',
         help='source file or directory to parse; repeatable',
         tags=['in_path'],
     )
-    index = scfg.Value(
+    index: list[str] | None = kwconf.Value(
         None,
         nargs='+',
         help=ub.paragraph(
@@ -49,7 +49,7 @@ class TheoryAuditCLI(scfg.DataConfig):
         ),
         tags=['in_path'],
     )
-    site_root = scfg.Value(
+    site_root: list[str] | None = kwconf.Value(
         None,
         nargs='+',
         help=ub.paragraph(
@@ -62,13 +62,15 @@ class TheoryAuditCLI(scfg.DataConfig):
             """
         ),
     )
-    format = scfg.Value(
+    format: str = kwconf.Value(
         'text',
         choices=['text', 'json'],
         help='text for a readable report, json for a machine-readable one',
     )
-    out = scfg.Value(None, help='write the report here instead of stdout', tags=['out_path'])
-    strict = scfg.Value(
+    out: str | None = kwconf.Value(
+        None, help='write the report here instead of stdout', tags=['out_path']
+    )
+    strict: bool = kwconf.Value(
         False,
         isflag=True,
         help=ub.paragraph(

--- a/magnet/theory/audit.py
+++ b/magnet/theory/audit.py
@@ -183,7 +183,12 @@ def audit(sources, indexes=(), site_roots=None) -> AuditReport:
     """
     from magnet.theory.basis import TheoreticalBasis
     from magnet.theory.index import load
-    from magnet.theory.static import StaticLedger, check_sites, extract_tree, lint
+    from magnet.theory.static import (
+        StaticLedger,
+        check_sites,
+        extract_tree,
+        lint,
+    )
 
     formalizations = [load(path) for path in indexes]
 

--- a/magnet/theory/audit.py
+++ b/magnet/theory/audit.py
@@ -49,6 +49,19 @@ class TheoryAuditCLI(scfg.DataConfig):
         ),
         tags=['in_path'],
     )
+    site_root = scfg.Value(
+        None,
+        nargs='+',
+        help=ub.paragraph(
+            """
+            ``package=directory`` mapping used to check that externally
+            declared ``site=`` references still point at real code; repeatable.
+            An edge declared away from its code site carries a string, and
+            nothing about a string keeps it true -- this is what catches it
+            going stale.
+            """
+        ),
+    )
     format = scfg.Value(
         'text',
         choices=['text', 'json'],
@@ -74,6 +87,7 @@ class TheoryAuditCLI(scfg.DataConfig):
         report = audit(
             sources=_as_list(config['source']),
             indexes=_as_list(config['index']),
+            site_roots=_parse_roots(_as_list(config['site_root'])),
         )
 
         if config['format'] == 'json':
@@ -157,17 +171,19 @@ class AuditReport:
         return '\n'.join(lines)
 
 
-def audit(sources, indexes=()) -> AuditReport:
+def audit(sources, indexes=(), site_roots=None) -> AuditReport:
     """
     Parse ``sources``, resolve against ``indexes``, and report.
 
     Args:
         sources: files or directories to parse.
         indexes: theorem indexes or ``formalization.yaml`` files.
+        site_roots: package -> directory, for validating declared ``site=``
+            references. Omitting it skips that check rather than passing it.
     """
     from magnet.theory.basis import TheoreticalBasis
     from magnet.theory.index import load
-    from magnet.theory.static import StaticLedger, extract_tree, lint
+    from magnet.theory.static import StaticLedger, check_sites, extract_tree, lint
 
     formalizations = [load(path) for path in indexes]
 
@@ -176,8 +192,21 @@ def audit(sources, indexes=()) -> AuditReport:
         ledger.extend(extract_tree(source))
 
     issues = lint(ledger, formalizations)
+    if site_roots:
+        issues.extend(check_sites(ledger, site_roots))
     basis = TheoreticalBasis.from_ledger(ledger, formalizations)
     return AuditReport(ledger, issues, basis, formalizations)
+
+
+def _parse_roots(items) -> dict:
+    """Parse ``package=directory`` arguments."""
+    roots = {}
+    for item in items:
+        package, sep, directory = str(item).partition('=')
+        if not sep:
+            raise ValueError(f'--site-root expects package=directory, got {item!r}')
+        roots[package.strip()] = directory.strip()
+    return roots
 
 
 def _as_list(value):

--- a/magnet/theory/audit.py
+++ b/magnet/theory/audit.py
@@ -1,0 +1,194 @@
+"""
+Audit a repository's theory annotations without running any of it.
+
+Parses a source tree, resolves what it declares against one or more theorem
+indexes, and prints the assumption ledger: which hypotheses are discharged,
+which are relaxed and how badly, and which nobody has looked at.
+
+Nothing here withholds or downgrades a verdict. The output is context to hang
+next to one -- and a work list, since every ``assumes`` in it is an invitation
+to write a :func:`~magnet.theory.predicates.checks` and find out.
+
+CommandLine:
+    python -m magnet.theory.audit --source path/to/team/repo \\
+        --index theory/indexes/some-formalization.yaml
+
+    python -m magnet.theory.audit --source . --index idx.yaml --format json
+"""
+import sys
+
+import scriptconfig as scfg
+import ubelt as ub
+
+__all__ = ['TheoryAuditCLI', 'audit']
+
+
+class TheoryAuditCLI(scfg.DataConfig):
+    """
+    Report what a codebase assumes, and what proves it.
+    """
+
+    __command__ = 'audit'
+
+    source = scfg.Value(
+        '.',
+        position=1,
+        nargs='+',
+        help='source file or directory to parse; repeatable',
+        tags=['in_path'],
+    )
+    index = scfg.Value(
+        None,
+        nargs='+',
+        help=ub.paragraph(
+            """
+            Theorem index or formalization.yaml to resolve references against;
+            repeatable. Without one, references cannot be checked and coverage
+            is reported as unknown.
+            """
+        ),
+        tags=['in_path'],
+    )
+    format = scfg.Value(
+        'text',
+        choices=['text', 'json'],
+        help='text for a readable report, json for a machine-readable one',
+    )
+    out = scfg.Value(None, help='write the report here instead of stdout', tags=['out_path'])
+    strict = scfg.Value(
+        False,
+        isflag=True,
+        help=ub.paragraph(
+            """
+            Exit nonzero if the lint finds problems. Lint problems are broken
+            references and unreadable annotations -- defects in the ledger
+            itself. Unaccounted hypotheses are never an error; they are the
+            report's whole point.
+            """
+        ),
+    )
+
+    @classmethod
+    def main(cls, argv=None, **kwargs):
+        config = cls.cli(argv=argv, data=kwargs, strict=True)
+        report = audit(
+            sources=_as_list(config['source']),
+            indexes=_as_list(config['index']),
+        )
+
+        if config['format'] == 'json':
+            import json
+
+            text = json.dumps(report.to_dict(), indent=2, ensure_ascii=False, default=str)
+        else:
+            text = report.render()
+
+        if config['out']:
+            path = ub.Path(config['out'])
+            path.parent.ensuredir()
+            path.write_text(text + '\n')
+            print(f'Wrote report to: {path}')
+        else:
+            print(text)
+
+        if config['strict'] and report.issues:
+            sys.exit(1)
+
+
+class AuditReport:
+    """The result of auditing a tree: the ledger, the lint, and the coverage."""
+
+    def __init__(self, ledger, issues, basis, formalizations):
+        self.ledger = ledger
+        self.issues = issues
+        self.basis = basis
+        self.formalizations = formalizations
+
+    def to_dict(self) -> dict:
+        return {
+            'formalizations': [
+                {
+                    'name': f.name,
+                    'repository': f.repository,
+                    'commit': f.commit,
+                    'review': str(f.review),
+                    'statements': len(f),
+                }
+                for f in self.formalizations
+            ],
+            'ledger': self.ledger.to_dict(),
+            'issues': [i.to_dict() for i in self.issues],
+            'basis': self.basis.to_dict(),
+        }
+
+    def render(self) -> str:
+        lines = []
+        for formalization in self.formalizations:
+            pin = (formalization.commit or 'unpinned')[:12]
+            lines.append(
+                f'formalization: {formalization.name}  '
+                f'[{len(formalization)} statements, {formalization.review}, pin {pin}]'
+            )
+        if self.formalizations:
+            lines.append('')
+
+        annotations = self.ledger.annotations
+        lines.append(
+            f'declared: {len(annotations)} annotations '
+            f'({len(self.ledger.groundings)} groundings, {len(self.ledger.edges)} edges) '
+            f'across {len({a.file for a in annotations})} files'
+        )
+        by_form: dict[str, int] = {}
+        for annotation in annotations:
+            by_form[annotation.form] = by_form.get(annotation.form, 0) + 1
+        if by_form:
+            lines.append('          ' + ', '.join(f'{v} {k}' for k, v in sorted(by_form.items())))
+        lines.append('')
+
+        if self.issues:
+            lines.append(f'issues: {len(self.issues)}')
+            for issue in self.issues:
+                lines.append(f'  {issue}')
+            lines.append('')
+
+        lines.append(self.basis.coverage().summary())
+        lines.append('')
+        lines.append(self.basis.render())
+        return '\n'.join(lines)
+
+
+def audit(sources, indexes=()) -> AuditReport:
+    """
+    Parse ``sources``, resolve against ``indexes``, and report.
+
+    Args:
+        sources: files or directories to parse.
+        indexes: theorem indexes or ``formalization.yaml`` files.
+    """
+    from magnet.theory.basis import TheoreticalBasis
+    from magnet.theory.index import load
+    from magnet.theory.static import StaticLedger, extract_tree, lint
+
+    formalizations = [load(path) for path in indexes]
+
+    ledger = StaticLedger()
+    for source in sources:
+        ledger.extend(extract_tree(source))
+
+    issues = lint(ledger, formalizations)
+    basis = TheoreticalBasis.from_ledger(ledger, formalizations)
+    return AuditReport(ledger, issues, basis, formalizations)
+
+
+def _as_list(value):
+    if value is None:
+        return []
+    if isinstance(value, (list, tuple)):
+        return list(value)
+    return [value]
+
+
+__cli__ = TheoryAuditCLI
+
+if __name__ == '__main__':
+    __cli__.main()

--- a/magnet/theory/basis.py
+++ b/magnet/theory/basis.py
@@ -13,7 +13,7 @@ belongs next to the verdict, because VERIFIED standing on two assumptions
 nobody has examined is a materially weaker statement than VERIFIED standing on
 none, and without this accounting nothing in the system can tell them apart.
 """
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Iterable, Sequence
 
 from magnet.theory.model import (
@@ -210,6 +210,11 @@ class TheoreticalBasis:
         registry for any hypothesis of a grounding statement, because the
         relaxations are usually in code the card calls rather than code it
         contains.
+
+        A grounding that names its ``formalization=`` contributes it here, so a
+        card that declares where its theorem came from does not also have to be
+        handed the same body a second time. Explicitly passed formalizations
+        come first, and win when both name the same declaration.
         """
         groundings = list(extra_groundings)
         edges = []
@@ -233,10 +238,18 @@ class TheoreticalBasis:
                 if edge.ref.declaration in grounded:
                     push(edge)
 
+        bodies = list(formalizations)
+        known = {id(f) for f in bodies}
+        for grounding in groundings:
+            body = getattr(grounding, 'formalization', None)
+            if body is not None and id(body) not in known:
+                known.add(id(body))
+                bodies.append(body)
+
         return cls(
             groundings=tuple(groundings),
             edges=tuple(edges),
-            formalizations=tuple(formalizations),
+            formalizations=tuple(bodies),
         )
 
     @classmethod

--- a/magnet/theory/basis.py
+++ b/magnet/theory/basis.py
@@ -1,0 +1,472 @@
+"""
+Assembling edges into a card's theoretical component, and accounting for them.
+
+The accounting is the product. Naming a grounding statement names its
+hypothesis list, so every hypothesis then has to be one of:
+
+    discharged   -- an edge says the experiment establishes it
+    a gap        -- an edge says how the experiment departs from it
+    unaccounted  -- no edge at all; nobody has looked
+
+Unaccounted is not an error and never withholds a verdict. It is context that
+belongs next to the verdict, because VERIFIED standing on two assumptions
+nobody has examined is a materially weaker statement than VERIFIED standing on
+none, and without this accounting nothing in the system can tell them apart.
+"""
+from dataclasses import dataclass, field
+from typing import Iterable, Sequence
+
+from magnet.theory.model import (
+    Freshness,
+    Hypothesis,
+    ProofStatus,
+    Relation,
+    Severity,
+    Theorem,
+    max_severity,
+    severity_rank,
+)
+from magnet.theory.registry import REGISTRY
+
+__all__ = ['AssumptionCoverage', 'CoverageReport', 'TheoreticalBasis']
+
+
+@dataclass
+class AssumptionCoverage:
+    """Per-statement accounting."""
+
+    theorem: Theorem
+    discharged: tuple = ()
+    gaps: tuple = ()
+    unaccounted: tuple[Hypothesis, ...] = ()
+    orphaned: tuple = ()
+
+    @property
+    def enumerated(self) -> bool:
+        return self.theorem.hypotheses_enumerated
+
+    @property
+    def is_complete(self) -> bool:
+        """
+        Every hypothesis accounted for and none orphaned.
+
+        False when the hypotheses were never enumerated: a statement whose
+        binders nobody exported is not a covered one.
+        """
+        return self.enumerated and not self.unaccounted and not self.orphaned
+
+    @property
+    def max_severity(self) -> Severity:
+        return max_severity([e.resolved_severity for e in self.gaps])
+
+    @property
+    def failed_checks(self) -> tuple:
+        """Checkers that ran and came back false -- measured contradictions."""
+        return tuple(e for e in self.gaps if e.check_outcome == 'failed')
+
+    def to_dict(self) -> dict:
+        return {
+            'theorem': self.theorem.declaration,
+            'informal': self.theorem.informal,
+            'proof': str(self.theorem.proof),
+            'review': str(self.theorem.review),
+            'extra_axioms': list(self.theorem.extra_axioms),
+            'hypotheses_enumerated': self.enumerated,
+            'complete': self.is_complete,
+            'max_severity': str(self.max_severity),
+            'discharged': [e.to_dict() for e in self.discharged],
+            'gaps': [e.to_dict() for e in self.gaps],
+            'unaccounted': [
+                {'name': h.name, 'informal': h.informal, 'structural': h.structural}
+                for h in self.unaccounted
+            ],
+            'orphaned': [e.to_dict() for e in self.orphaned],
+        }
+
+
+@dataclass
+class CoverageReport:
+    """Accounting across every statement a card is grounded on."""
+
+    per_theorem: tuple[AssumptionCoverage, ...] = ()
+    #: Edges naming a statement nothing is grounded on. Without this they would
+    #: be silently dropped -- an author writes an edge, it never appears, and
+    #: nothing says why. Usually it means a grounding is missing, or the edge
+    #: belongs on a different statement.
+    dangling: tuple = ()
+
+    @property
+    def is_complete(self) -> bool:
+        return (
+            bool(self.per_theorem)
+            and not self.dangling
+            and all(c.is_complete for c in self.per_theorem)
+        )
+
+    @property
+    def max_severity(self) -> Severity:
+        return max_severity([c.max_severity for c in self.per_theorem])
+
+    @property
+    def unaccounted(self) -> tuple[Hypothesis, ...]:
+        return tuple(h for c in self.per_theorem for h in c.unaccounted)
+
+    @property
+    def failed_checks(self) -> tuple:
+        return tuple(e for c in self.per_theorem for e in c.failed_checks)
+
+    @property
+    def unproved(self) -> tuple[Theorem, ...]:
+        """Grounding statements not closed under the kernel axioms."""
+        return tuple(c.theorem for c in self.per_theorem if c.theorem.proof is not ProofStatus.PROVED)
+
+    @property
+    def stale(self) -> tuple:
+        """Edges whose reference no longer resolves at the pinned commit."""
+        return tuple(
+            e
+            for c in self.per_theorem
+            for e in (c.gaps + c.discharged + c.orphaned)
+            if e.freshness in (Freshness.STALE, Freshness.BROKEN)
+        )
+
+    def summary(self) -> str:
+        """
+        One line, for printing next to a verdict.
+
+        Example:
+            >>> CoverageReport().summary()
+            'not grounded on any statement'
+        """
+        if not self.per_theorem:
+            return 'not grounded on any statement'
+
+        n_discharged = sum(len(c.discharged) for c in self.per_theorem)
+        n_gaps = sum(len(c.gaps) for c in self.per_theorem)
+        n_unaccounted = sum(len(c.unaccounted) for c in self.per_theorem)
+        n_unknown = sum(1 for c in self.per_theorem if not c.enumerated)
+        total = n_discharged + n_gaps + n_unaccounted
+
+        parts = []
+        if n_discharged:
+            parts.append(f'{n_discharged} discharged')
+        if n_gaps:
+            parts.append(f'{n_gaps} relaxed (max severity {self.max_severity})')
+        if n_unaccounted:
+            parts.append(f'{n_unaccounted} unaccounted')
+
+        if not total:
+            body = 'no assumptions recorded'
+        else:
+            noun = 'assumption' if total == 1 else 'assumptions'
+            body = f'standing on {total} {noun}: ' + ', '.join(parts)
+
+        if n_unknown:
+            plural = '' if n_unknown == 1 else 's'
+            body += f' ({n_unknown} statement{plural} with hypotheses not enumerated)'
+        if self.dangling:
+            body += f'; {len(self.dangling)} dangling'
+        return body
+
+    def to_dict(self) -> dict:
+        return {
+            'complete': self.is_complete,
+            'max_severity': str(self.max_severity),
+            'summary': self.summary(),
+            'failed_checks': [e.to_dict() for e in self.failed_checks],
+            'statements': [c.to_dict() for c in self.per_theorem],
+            'dangling': [e.to_dict() for e in self.dangling],
+        }
+
+
+@dataclass
+class TheoreticalBasis:
+    """
+    The theoretical component of a card.
+
+    What the statements give you, what the experiment gave up to be runnable,
+    and whether anything fell between the two.
+    """
+
+    groundings: tuple = ()
+    edges: tuple = ()
+    formalizations: tuple = ()
+
+    @classmethod
+    def collect(
+        cls,
+        *objects,
+        registry=REGISTRY,
+        extra_edges: Sequence = (),
+        extra_groundings: Sequence = (),
+        formalizations: Iterable = (),
+    ) -> 'TheoreticalBasis':
+        """
+        Gather annotations from decorated objects and the registry.
+
+        Groundings come from the objects passed in and from ``extra_groundings``
+        -- a card is grounded on what *it* claims, not on whatever else happens
+        to be imported. Edges are gathered more widely, including from the
+        registry for any hypothesis of a grounding statement, because the
+        relaxations are usually in code the card calls rather than code it
+        contains.
+        """
+        groundings = list(extra_groundings)
+        edges = []
+        seen: set[int] = set()
+
+        def push(edge) -> None:
+            if id(edge) not in seen:
+                seen.add(id(edge))
+                edges.append(edge)
+
+        for obj in objects:
+            groundings.extend(getattr(obj, '__magnet_groundings__', ()))
+            for edge in getattr(obj, '__magnet_edges__', ()):
+                push(edge)
+        for edge in extra_edges:
+            push(edge)
+
+        if registry is not None:
+            grounded = {g.ref.declaration for g in groundings}
+            for edge in registry.edges:
+                if edge.ref.declaration in grounded:
+                    push(edge)
+
+        return cls(
+            groundings=tuple(groundings),
+            edges=tuple(edges),
+            formalizations=tuple(formalizations),
+        )
+
+    @classmethod
+    def from_ledger(cls, ledger, formalizations: Iterable = ()) -> 'TheoreticalBasis':
+        """
+        Build a basis from statically extracted annotations.
+
+        This is the path that does not execute anything: parse a repository,
+        turn what it declares into the same :class:`~magnet.theory.predicates.Edge`
+        and :class:`~magnet.theory.predicates.Grounding` objects the runtime
+        produces, and report on them identically. The only thing missing is
+        evidence -- no observations, no witnessed values, no check outcomes,
+        since nothing ran.
+
+        Unresolvable annotations are skipped here and surfaced by
+        :func:`magnet.theory.static.lint` instead; a reference nobody can read
+        is a lint error, not a silent hole in the ledger.
+        """
+        from magnet.theory.predicates import Edge, Grounding
+        from magnet.theory.registry import TheoryRegistry
+
+        scratch = TheoryRegistry()
+        groundings = []
+        edges = []
+        for annotation in ledger.annotations:
+            if not annotation.resolved:
+                continue
+            options = dict(annotation.options)
+            options.pop('registry', None)
+            options.pop('observe', None)
+            options.pop('witness_params', None)
+            site = options.pop('site', None) or annotation.site
+            if annotation.predicate == 'grounds':
+                groundings.append(
+                    Grounding(annotation.ref, site=site, registry=scratch, **options)
+                )
+            else:
+                relation = (
+                    Relation.CHECKS
+                    if annotation.predicate == 'checks'
+                    else Relation(annotation.predicate)
+                )
+                severity = options.pop('severity', None)
+                edges.append(
+                    Edge(
+                        annotation.ref,
+                        relation=relation,
+                        severity=severity,
+                        site=site,
+                        registry=scratch,
+                        **options,
+                    )
+                )
+        basis = cls(
+            groundings=tuple(groundings),
+            edges=tuple(edges),
+            formalizations=tuple(formalizations),
+        )
+        return basis.resolve() if formalizations else basis
+
+    # ------------------------------------------------------------- resolution
+
+    def resolve(self, *formalizations) -> 'TheoreticalBasis':
+        """
+        Attach real statements to the references, and set freshness.
+
+        Until this runs, a basis is a bag of strings: it knows what the code
+        *claims* about itself and nothing about whether those claims name
+        anything real. Resolution is where a reference to a renamed binder
+        becomes visible as :attr:`Freshness.BROKEN` rather than passing silently.
+        """
+        sources = list(formalizations) or list(self.formalizations)
+        for annotation in list(self.groundings) + list(self.edges):
+            annotation.freshness = Freshness.UNKNOWN
+            for formalization in sources:
+                try:
+                    formalization.resolve(annotation.ref)
+                except KeyError:
+                    if annotation.ref.declaration in formalization:
+                        annotation.freshness = Freshness.BROKEN
+                    continue
+                annotation.freshness = Freshness.CURRENT
+                break
+        return TheoreticalBasis(
+            groundings=self.groundings,
+            edges=self.edges,
+            formalizations=tuple(sources),
+        )
+
+    def statements(self) -> tuple[Theorem, ...]:
+        """
+        The grounding statements, resolved against the formalizations if any.
+
+        A grounding whose declaration is not in any loaded formalization still
+        yields a placeholder, so an unresolvable reference shows up in the
+        report instead of vanishing from it.
+        """
+        out: dict[str, Theorem] = {}
+        for grounding in self.groundings:
+            declaration = grounding.ref.declaration
+            if declaration in out:
+                continue
+            theorem = None
+            for formalization in self.formalizations:
+                if declaration in formalization:
+                    theorem = formalization[declaration]
+                    break
+            if theorem is None:
+                theorem = Theorem(
+                    declaration=declaration,
+                    informal=grounding.informal,
+                    note='not found in any loaded formalization',
+                )
+            out[declaration] = theorem
+        return tuple(out.values())
+
+    def coverage(self) -> CoverageReport:
+        """Account for every hypothesis of every grounding statement."""
+        per_theorem = []
+        for theorem in self.statements():
+            edges = [e for e in self.edges if e.ref.declaration == theorem.declaration]
+            names = {h.name for h in theorem.hypotheses}
+
+            if theorem.hypotheses_enumerated:
+                orphaned = tuple(e for e in edges if e.ref.hypothesis not in names)
+                live = [e for e in edges if e.ref.hypothesis in names]
+            else:
+                orphaned = ()
+                live = edges
+
+            discharged = tuple(e for e in live if not e.is_gap)
+            gaps = tuple(
+                sorted(
+                    (e for e in live if e.is_gap),
+                    key=lambda e: -severity_rank(e.resolved_severity),
+                )
+            )
+            covered = {e.ref.hypothesis for e in live}
+            unaccounted = tuple(h for h in theorem.hypotheses if h.name not in covered)
+
+            per_theorem.append(
+                AssumptionCoverage(
+                    theorem=theorem,
+                    discharged=discharged,
+                    gaps=gaps,
+                    unaccounted=unaccounted,
+                    orphaned=orphaned,
+                )
+            )
+        grounded = {t.declaration for t in self.statements()}
+        dangling = tuple(e for e in self.edges if e.ref.declaration not in grounded)
+        return CoverageReport(per_theorem=tuple(per_theorem), dangling=dangling)
+
+    # -------------------------------------------------------------- reporting
+
+    def to_dict(self) -> dict:
+        return {
+            'formalizations': [
+                {
+                    'name': f.name,
+                    'repository': f.repository,
+                    'commit': f.commit,
+                    'review': str(f.review),
+                }
+                for f in self.formalizations
+            ],
+            'groundings': [g.to_dict() for g in self.groundings],
+            'edges': [e.to_dict() for e in self.edges],
+            'coverage': self.coverage().to_dict(),
+        }
+
+    def render(self) -> str:
+        """A human-readable edge table, ordered by severity."""
+        lines: list[str] = []
+        for cov in self.coverage().per_theorem:
+            theorem = cov.theorem
+            lines.append(f'{theorem.declaration}  [{theorem.proof}, {theorem.review}]')
+            if theorem.informal:
+                lines.append(f'    {theorem.informal}')
+            if theorem.extra_axioms:
+                lines.append(f'    extra axioms: {", ".join(theorem.extra_axioms)}')
+
+            for edge in cov.gaps + cov.discharged:
+                marker = f'[{edge.resolved_severity:6}]'
+                relation = str(edge.relation)
+                if edge.check_outcome:
+                    relation = f'{relation} ({edge.check_outcome})'
+                lines.append(f'    {marker} {edge.ref.hypothesis}: {relation}')
+                hypothesis = _find_hypothesis(theorem, edge.ref.hypothesis)
+                if hypothesis is not None and hypothesis.informal:
+                    lines.append(f'             ideal:  {hypothesis.informal}')
+                if edge.informal:
+                    lines.append(f'             actual: {edge.informal}')
+                if edge.evidence:
+                    lines.append(f'             proof:  {edge.evidence}')
+                if edge.site:
+                    lines.append(f'             site:   {edge.site}')
+            for hypothesis in cov.unaccounted:
+                tag = 'UNACCOUNTED' + (' (structural)' if hypothesis.structural else '')
+                lines.append(f'    [{tag}] {hypothesis.name}: {hypothesis.informal}')
+            for edge in cov.orphaned:
+                lines.append(
+                    f'    [ORPHANED] {edge.ref.hypothesis} is not a hypothesis of this statement'
+                )
+
+            if cov.is_complete:
+                lines.append('    coverage: complete')
+            elif not cov.enumerated:
+                lines.append('    coverage: UNKNOWN (hypotheses not enumerated)')
+            else:
+                unmet = len(cov.unaccounted) + len(cov.orphaned)
+                lines.append(f'    coverage: INCOMPLETE ({unmet} unaccounted or orphaned)')
+            lines.append('')
+
+        report = self.coverage()
+        if report.dangling:
+            lines.append('dangling -- these name a statement nothing is grounded on:')
+            for edge in report.dangling:
+                lines.append(f'    {edge.relation} {edge.ref.key}')
+                if edge.site:
+                    lines.append(f'             site:   {edge.site}')
+            lines.append('')
+
+        if not lines:
+            return 'no theoretical basis recorded'
+        return '\n'.join(lines).rstrip()
+
+
+def _find_hypothesis(theorem: Theorem, name) -> Hypothesis | None:
+    for hypothesis in theorem.hypotheses:
+        if hypothesis.name == name:
+            return hypothesis
+    return None

--- a/magnet/theory/data/hygiene.yaml
+++ b/magnet/theory/data/hygiene.yaml
@@ -1,0 +1,169 @@
+# Shared evaluation-hygiene statements.
+#
+# Most empirical evaluation claims are not backed by a bespoke theorem, and
+# never will be. But they are not assumption-free either: they lean on the same
+# handful of premises over and over -- that the evaluation sample is iid, that
+# the automatic scorer tracks what it proxies, that the sample is large enough
+# for the threshold being asserted, that the threshold was not chosen after
+# looking. Those premises are shared, so the statements about them can be too.
+#
+# The point of this library is that a card with no theory of its own still has
+# somewhere to attach its assumptions. "There is no theorem here" is a finding
+# worth recording precisely; "there is nothing to say about this card" is not,
+# and it is usually false.
+#
+# The workhorse is Concentration.mean_within_tolerance. It turns "where does the
+# 0.05 threshold come from?" from a rhetorical question into a computable one:
+# given your tolerance and your confidence, what sample size do you need, and do
+# you have it? A card that grounds here and cannot discharge `hn` has learned
+# something specific, and it needed no bespoke theory to learn it.
+#
+# Every statement here is UNPROVED -- `proof: unknown`, `review: draft`. They are
+# stated, not formalized. Hoeffding and split-conformal coverage are both within
+# reach of Mathlib and are the obvious first two to actually prove; the
+# measurement bundle at the end is definitional and is not a proof target at
+# all. Stating them is still most of the value, because a statement cannot be
+# written without naming its hypotheses, and naming them is what the cards need.
+
+version: 1
+
+project:
+  name: "Evaluation hygiene"
+  review: "draft"
+  note: >
+    Shared statements every evaluation card can ground on, independent of
+    whether its method has a theory. Nothing here is formalized yet; proof
+    status is unknown throughout and should stay that way until a Lean
+    development exists. Hypothesis binder names are the contract -- cards draw
+    edges against them, so renaming one breaks every card that used it.
+
+theorems:
+
+  - declaration: "Hygiene.Concentration.mean_within_tolerance"
+    review: "draft"
+    informal: >
+      A sample mean of bounded iid draws is within a stated tolerance of the
+      population mean, with a stated confidence, once the sample is large
+      enough. Hoeffding's inequality.
+    conclusion: >
+      P(|sampleMean X n - populationMean X| >= eps) <= delta,
+      whenever n >= ceil(log(2/delta) / (2 * eps^2)).
+    note: >
+      The sample-size hypothesis `hn` is the one worth computing rather than
+      asserting. At eps = 0.05 and delta = 0.05 it needs n >= 738; at eps = 0.01
+      it needs n >= 18445. Many cards report thresholds finer than their
+      evaluation sets can support, and this is the statement that makes that
+      visible.
+    hypotheses:
+      - name: "hiid"
+        informal: "the evaluation instances are independent and identically distributed draws from the target distribution"
+      - name: "hbdd"
+        informal: "the per-instance score is bounded in a known range, typically [0,1]"
+      - name: "hn"
+        informal: "the sample size is at least the Hoeffding bound for the asserted tolerance and confidence"
+
+  - declaration: "Hygiene.Concentration.paired_difference_within_tolerance"
+    review: "draft"
+    informal: >
+      A difference of two sample means, measured on paired instances, is within
+      a stated tolerance of the population difference. The form most threshold
+      cards actually take -- an accuracy drop, a lift, a gap.
+    conclusion: >
+      P(|(sampleMean A n - sampleMean B n) - (populationMean A - populationMean B)| >= eps) <= delta,
+      whenever n >= ceil(log(2/delta) / (2 * eps^2)) for the per-instance difference.
+    note: >
+      Pairing matters: the tolerance is on the difference sequence, not on each
+      arm separately, so a card that evaluates both arms on the same instances
+      needs a smaller n than one that does not. A card that pairs but computes
+      the bound as though it did not is being conservative; one that does not
+      pair but assumes it did is not.
+    hypotheses:
+      - name: "hiid"
+        informal: "the instances are iid draws from the target distribution"
+      - name: "hbdd"
+        informal: "both per-instance scores are bounded in a known range"
+      - name: "hpaired"
+        informal: "both conditions are evaluated on the same instances, so the difference is a per-instance quantity"
+      - name: "hn"
+        informal: "the sample size is at least the bound for the asserted tolerance and confidence"
+
+  - declaration: "Hygiene.Conformal.marginal_coverage_of_exchangeable"
+    review: "draft"
+    informal: >
+      Split (inductive) conformal prediction attains its nominal marginal
+      coverage, distribution-free, under exchangeability of the calibration and
+      test scores.
+    conclusion: >
+      1 - alpha <= P(Y_test in C_alpha(X_test)) <= 1 - alpha + 1/(n_cal + 1)
+    note: >
+      An order-statistics argument, not a distributional one: no assumption is
+      made about the residuals. That is exactly what makes substituting a
+      Gaussian interval -- mean plus or minus two standard deviations -- a
+      strictly stronger and unproven claim, even though it looks like the same
+      95 percent.
+    hypotheses:
+      - name: "hexch"
+        informal: "the calibration and test nonconformity scores are exchangeable"
+      - name: "hsplit"
+        informal: >
+          the calibration split is used ONLY for the quantile: the predictor,
+          the score function, and any model selection are fixed before it is
+          touched
+      - name: "hscore_fixed"
+        informal: "the nonconformity score function does not depend on the calibration data"
+      - name: "hquantile"
+        informal: "the interval is formed from the empirical (1-alpha) quantile of the calibration scores"
+
+  - declaration: "Hygiene.Inference.threshold_exceeds_sampling_error"
+    review: "draft"
+    informal: >
+      An observed statistic exceeding a threshold is evidence about the
+      population only when the threshold exceeds what sampling noise alone would
+      produce, at the confidence being claimed, after accounting for how many
+      comparisons were made.
+    conclusion: >
+      If the observed statistic exceeds `threshold` and `threshold` exceeds the
+      sampling error at level delta / m, then the population statistic is
+      positive with confidence 1 - delta.
+    note: >
+      This is where a bare "drag >= 0.05" or "AUC >= 0.65" card should ground
+      when it has nothing else. Its three hypotheses are the three questions to
+      ask such a card, and all three are checkable from the card itself: was the
+      threshold fixed in advance, is n big enough, and how many comparisons were
+      run.
+    hypotheses:
+      - name: "hprespecified"
+        informal: "the threshold was fixed before the results were seen"
+      - name: "hn_sufficient"
+        informal: "the sample size supports resolving a difference of this size at the claimed confidence"
+      - name: "hmultiple"
+        informal: >
+          the confidence level accounts for the number of comparisons in the
+          family -- models, datasets, metrics, and sweep points all count
+
+  - declaration: "Hygiene.Measurement.measured_score_tracks_construct"
+    review: "draft"
+    informal: >
+      What a card measures is what it claims to be measuring: the automatic
+      scorer tracks the construct, the evaluation data is not in training, and
+      the measurement is stable under nuisance variation.
+    conclusion: >
+      The measured statistic is an estimate of the construct the claim is about.
+    note: >
+      DEFINITIONAL, not a theorem, and it is listed as a statement anyway so
+      that cards have a place to record these assumptions instead of leaving
+      them unwritten. Do not try to prove it. Its value is entirely in forcing
+      three questions to be answered per card, and in making an unanswered one
+      show up as unaccounted.
+    hypotheses:
+      - name: "hscorer"
+        informal: >
+          the automatic scorer agrees with the construct it proxies -- exact
+          match for correctness, an n-gram overlap for translation quality, a
+          judge model for helpfulness
+      - name: "hcontam"
+        informal: "the evaluation instances are not in the models' training data"
+      - name: "hstable"
+        informal: >
+          the measurement is stable under nuisance variation: decoding seed,
+          prompt ordering, formatting, and hardware

--- a/magnet/theory/index.py
+++ b/magnet/theory/index.py
@@ -1,0 +1,270 @@
+"""
+Loading statements from disk.
+
+Two formats, for two different situations.
+
+A **theorem index** is what a formalization repository exports for downstream
+consumers: declaration, conclusion, hypothesis binders, axioms, file and line.
+It is the only format that supports hypothesis-level coverage, because it is the
+only one that carries binders. Its shape is the contract between the Lean side
+and this package::
+
+    version: 1
+    project:
+      name: ...
+      repository: ...
+      commit: <sha>          # what every reference is pinned to
+      review: self-assessed
+    theorems:
+      - declaration: Some.Namespace.the_theorem
+        informal: "..."
+        conclusion: "MSE(candidate) <= MSE(baseline), eventually, w.h.p."
+        file: Some/Namespace/File.lean
+        line: 291
+        axioms: [propext, Classical.choice, Quot.sound]
+        hypotheses:
+          - name: hgap
+            informal: "the affine witness beats the baseline in population MSE"
+            lean: "MSE Pf (yFull score Qstar) (affineModel theta (psi Qols)) < ..."
+            structural: false
+
+A **formalization manifest** (``formalization.yaml``, the mathlib-initiative
+v0.3 schema) is metadata about a project rather than an export of its
+statements: it names capstones and pairs some with informal descriptions, but it
+carries no binders. Loading one gets you declaration names and, where a note
+records an axiom audit, proof status -- enough to check that a reference names
+something real, not enough to audit assumptions. Statements loaded this way
+report ``hypotheses_enumerated == False`` so a missing exporter cannot pass for
+a clean bill of health.
+"""
+import os
+from typing import Any, Iterator, Sequence
+
+from magnet.theory.model import KERNEL_AXIOMS, Formalization, Hypothesis, Theorem
+
+#: The hygiene library shipped alongside this module.
+HYGIENE_PATH = os.path.join(os.path.dirname(__file__), 'data', 'hygiene.yaml')
+
+__all__ = ['load_index', 'load_manifest', 'save_index', 'load', 'hygiene', 'HYGIENE_PATH']
+
+
+def hygiene() -> Formalization:
+    """
+    The shared evaluation-hygiene statements shipped with MAGNET.
+
+    Most cards have no theory of their own, but they are not assumption-free:
+    they lean on the same premises repeatedly -- iid sampling, a scorer that
+    tracks its construct, a sample big enough for the threshold asserted, a
+    threshold not chosen after looking. Those are shared, so a card with no
+    bespoke theorem still has somewhere to attach its assumptions.
+
+    Example:
+        >>> from magnet.theory import hygiene
+        >>> library = hygiene()
+        >>> statement = library['Hygiene.Concentration.mean_within_tolerance']
+        >>> [h.name for h in statement.hypotheses]
+        ['hiid', 'hbdd', 'hn']
+        >>> statement.proof
+        <ProofStatus.UNKNOWN: 'unknown'>
+    """
+    return load_index(HYGIENE_PATH)
+
+
+def load(path, name: str | None = None) -> Formalization:
+    """
+    Load either format, choosing by filename.
+
+    ``formalization.yaml`` is the manifest; anything else is an index.
+    """
+    import ubelt as ub
+
+    path = ub.Path(path)
+    if path.name == 'formalization.yaml':
+        return load_manifest(path, name=name)
+    return load_index(path, name=name)
+
+
+def load_index(path, name: str | None = None) -> Formalization:
+    """Load a theorem index (JSON or YAML, by extension)."""
+    import ubelt as ub
+
+    path = ub.Path(path)
+    data = _read_structured(path)
+
+    project = data.get('project') or {}
+    formalization = Formalization(
+        name=name or project.get('name') or path.parent.name,
+        repository=project.get('repository'),
+        commit=project.get('commit'),
+        source=str(path),
+        review=project.get('review', 'draft'),
+        note=project.get('note', ''),
+    )
+    for spec in data.get('theorems') or []:
+        formalization.add(
+            Theorem(
+                declaration=spec['declaration'],
+                informal=spec.get('informal', ''),
+                conclusion=spec.get('conclusion', ''),
+                hypotheses=[
+                    Hypothesis(
+                        name=h['name'],
+                        informal=h.get('informal', ''),
+                        lean=h.get('lean'),
+                        structural=bool(h.get('structural', False)),
+                    )
+                    for h in spec.get('hypotheses') or []
+                ],
+                axioms=spec.get('axioms'),
+                file=spec.get('file'),
+                line=spec.get('line'),
+                review=spec.get('review', 'draft'),
+                note=spec.get('note', ''),
+            )
+        )
+    return formalization
+
+
+def save_index(formalization: Formalization, path) -> None:
+    """Write a formalization back out as a theorem index."""
+    import ubelt as ub
+
+    path = ub.Path(path)
+    path.parent.ensuredir()
+    data = formalization.to_dict()
+    if path.suffix == '.json':
+        import json
+
+        path.write_text(json.dumps(data, indent=2, ensure_ascii=False) + '\n')
+    else:
+        import yaml
+
+        path.write_text(yaml.safe_dump(data, sort_keys=False, allow_unicode=True))
+
+
+def load_manifest(path, name: str | None = None) -> Formalization:
+    """Load a ``formalization.yaml`` (mathlib-initiative v0.3)."""
+    import ubelt as ub
+
+    path = ub.Path(path)
+    data = _read_structured(path)
+    project = data.get('project') or {}
+    review = (data.get('review') or {}).get('status', 'draft')
+
+    formalization = Formalization(
+        name=name or project.get('name') or path.parent.name,
+        repository=project.get('repository'),
+        source=str(path),
+        review=_coerce_review(review),
+    )
+
+    # Informal statements paired with declarations: the richest source, but it
+    # only covers the subset someone bothered to align.
+    for statement in (data.get('alignment') or {}).get('statements') or []:
+        declaration = statement.get('lean')
+        if declaration:
+            formalization.add(
+                Theorem(
+                    declaration=declaration,
+                    informal=statement.get('informal', ''),
+                    note=statement.get('status', ''),
+                )
+            )
+
+    # Capstone declarations appear under several groupings; rather than hardcode
+    # one shape, take every 'capstones' list in the document.
+    for ancestors, capstones in _walk_key(data, 'capstones'):
+        axioms = _axioms_from_notes(ancestors)
+        for declaration in capstones or []:
+            if not isinstance(declaration, str):
+                continue
+            existing = formalization.theorems.get(declaration)
+            if existing is None:
+                formalization.add(Theorem(declaration=declaration, axioms=axioms))
+            elif existing.axioms is None and axioms is not None:
+                formalization.add(
+                    Theorem(
+                        declaration=declaration,
+                        informal=existing.informal,
+                        conclusion=existing.conclusion,
+                        hypotheses=existing.hypotheses,
+                        axioms=axioms,
+                        file=existing.file,
+                        line=existing.line,
+                        review=existing.review,
+                        note=existing.note,
+                    )
+                )
+    return formalization
+
+
+def _read_structured(path) -> dict:
+    text = path.read_text()
+    if path.suffix == '.json':
+        import json
+
+        return json.loads(text) or {}
+    import yaml
+
+    return yaml.safe_load(text) or {}
+
+
+def _coerce_review(value: str) -> str:
+    from magnet.theory.model import ReviewStatus
+
+    try:
+        return str(ReviewStatus(value))
+    except ValueError:
+        return str(ReviewStatus.DRAFT)
+
+
+def _walk_key(node: Any, key: str, ancestors: tuple = ()) -> Iterator[tuple[tuple, Any]]:
+    """
+    Yield ``(ancestor_mappings, value)`` for every occurrence of ``key``.
+
+    Ancestors are nearest-first, so a caller can look for context -- an
+    axiom-audit note, say -- on the enclosing node and then further up.
+    """
+    if isinstance(node, dict):
+        chain = (node,) + ancestors
+        for k, v in node.items():
+            if k == key:
+                yield (chain, v)
+            yield from _walk_key(v, key, chain)
+    elif isinstance(node, list):
+        for item in node:
+            yield from _walk_key(item, key, ancestors)
+
+
+def _axioms_from_notes(ancestors: Sequence[dict]) -> tuple[str, ...] | None:
+    """
+    Recover an axiom set from a manifest's prose note.
+
+    Manifests record axiom audits as free text ("All capstones verified
+    ``#print axioms`` = {propext, Classical.choice, Quot.sound}"), attached to
+    whichever node groups the declarations it covers. Reading prose is a stopgap
+    for a real exporter, so it is deliberately narrow: only the exact kernel
+    axiom set is recognized, and anything else reads as unknown rather than
+    being guessed at.
+
+    Example:
+        >>> note = {'note': 'verified #print axioms = {propext, Classical.choice, Quot.sound}'}
+        >>> _axioms_from_notes([{}, note])
+        ('Classical.choice', 'Quot.sound', 'propext')
+        >>> _axioms_from_notes([{'note': 'looks fine to me'}]) is None
+        True
+    """
+    import re
+
+    for holder in ancestors:
+        note = ' '.join(
+            str(v) for k, v in holder.items() if k in {'note', 'notes'} and isinstance(v, str)
+        )
+        if not note or '#print axioms' not in note:
+            continue
+        braced = re.search(r'\{([^}]*)\}', note)
+        if braced:
+            named = {tok.strip() for tok in braced.group(1).split(',') if tok.strip()}
+            if named == set(KERNEL_AXIOMS):
+                return tuple(sorted(KERNEL_AXIOMS))
+    return None

--- a/magnet/theory/index.py
+++ b/magnet/theory/index.py
@@ -40,7 +40,12 @@ a clean bill of health.
 import os
 from typing import Any, Iterator, Sequence
 
-from magnet.theory.model import KERNEL_AXIOMS, Formalization, Hypothesis, Theorem
+from magnet.theory.model import (
+    KERNEL_AXIOMS,
+    Formalization,
+    Hypothesis,
+    Theorem,
+)
 
 #: The hygiene library shipped alongside this module.
 HYGIENE_PATH = os.path.join(os.path.dirname(__file__), 'data', 'hygiene.yaml')

--- a/magnet/theory/model.py
+++ b/magnet/theory/model.py
@@ -1,0 +1,677 @@
+"""
+The data model: formalizations, theorems, hypotheses, and the edges to code.
+
+A theorem holds *provided a list of explicit hypotheses*. An experiment almost
+never satisfies them literally -- it runs at finite sample, substitutes a
+tractable estimator, uses an off-the-shelf embedder, measures L1 where the
+theorem controls L2. An **edge** records one such correspondence:
+
+    edge = (a named hypothesis of a theorem) -> (the code that stands in for it)
+
+annotated with the *relation* between the two. The relation is the verb, and it
+is the field that matters most: ``satisfies`` and ``violates`` are opposite
+claims about the same pair, and burying that distinction inside a "kind" tag was
+the first thing this model got wrong.
+
+Three status axes are tracked separately, because they fail independently and a
+dashboard that merges them into one indicator will mislead:
+
+    proof      -- the kernel's verdict: proved, sorry, unknown
+    review     -- a human's verdict: draft ... accepted, rejected
+    freshness  -- whether the reference still resolves at the pinned commit
+
+A theorem can be proved, draft, and stale all at once. That is a common state,
+not a contradiction.
+"""
+from dataclasses import dataclass, field
+from enum import StrEnum
+from typing import Iterable, Iterator, Sequence
+
+__all__ = [
+    'Relation',
+    'Severity',
+    'ProofStatus',
+    'ReviewStatus',
+    'Freshness',
+    'Hypothesis',
+    'Theorem',
+    'Formalization',
+    'CodeSite',
+    'Observation',
+    'Check',
+    'HypothesisRef',
+    'parse_ref',
+    'KERNEL_AXIOMS',
+    'RELATION_DEFAULT_SEVERITY',
+    'GAP_RELATIONS',
+]
+
+
+#: Axioms Lean's kernel permits in a fully proved development. A theorem whose
+#: ``#print axioms`` output is a subset of these is proved outright; anything
+#: else (notably ``sorryAx``) means something is still assumed.
+KERNEL_AXIOMS = frozenset({'propext', 'Classical.choice', 'Quot.sound'})
+
+#: Separates a declaration from a hypothesis binder in a reference string.
+REF_SEPARATOR = '::'
+
+
+class Relation(StrEnum):
+    """
+    How a piece of code stands with respect to an idealized hypothesis.
+
+    These are the predicates. Each reads as a true sentence at the code site,
+    which is the test a candidate relation has to pass to belong here.
+    """
+
+    #: The experiment establishes it.
+    SATISFIES = 'satisfies'
+
+    #: The same object, in a finite or numerical version of it.
+    APPROXIMATES = 'approximates'
+
+    #: A *different* object stands in for the one the theorem is about.
+    SUBSTITUTES = 'substitutes'
+
+    #: Relied upon; nothing establishes or checks it.
+    ASSUMES = 'assumes'
+
+    #: A side condition delimiting the theorem's regime, simply dropped.
+    IGNORES = 'ignores'
+
+    #: Known to fail -- ideally with a proof, via ``evidence``.
+    VIOLATES = 'violates'
+
+    #: Tested at run time. The relation that resolves to satisfies or violates
+    #: depending on what the check returns; see :mod:`magnet.theory.predicates`.
+    CHECKS = 'checks'
+
+
+#: Relations that represent a departure from the theorem. ``satisfies`` does
+#: not; ``checks`` depends on its outcome and is resolved before this is used.
+GAP_RELATIONS = frozenset(
+    {
+        Relation.APPROXIMATES,
+        Relation.SUBSTITUTES,
+        Relation.ASSUMES,
+        Relation.IGNORES,
+        Relation.VIOLATES,
+    }
+)
+
+
+class Severity(StrEnum):
+    """
+    How load-bearing the gap is.
+
+    ``HIGH`` has a specific meaning worth holding to: *the proved theorem does
+    not cover the artifact*. Reserve it for that.
+    """
+
+    NONE = 'none'
+    LOW = 'low'
+    MEDIUM = 'medium'
+    HIGH = 'high'
+
+
+#: Per-relation default severity. An author can always override; these encode
+#: that substituting a different object is presumptively worse than
+#: approximating the right one.
+RELATION_DEFAULT_SEVERITY = {
+    Relation.SATISFIES: Severity.NONE,
+    Relation.CHECKS: Severity.NONE,
+    Relation.APPROXIMATES: Severity.MEDIUM,
+    Relation.ASSUMES: Severity.MEDIUM,
+    Relation.IGNORES: Severity.MEDIUM,
+    Relation.SUBSTITUTES: Severity.HIGH,
+    Relation.VIOLATES: Severity.HIGH,
+}
+
+
+class ProofStatus(StrEnum):
+    """The kernel's verdict. Not a human judgment."""
+
+    #: ``#print axioms`` is within :data:`KERNEL_AXIOMS`.
+    PROVED = 'proved'
+
+    #: Something is still assumed -- ``sorryAx`` or another extra axiom.
+    SORRY = 'sorry'
+
+    #: Never reported. A statement authored for a card that has no
+    #: formalization behind it yet lands here or in ``SORRY``.
+    UNKNOWN = 'unknown'
+
+
+class ReviewStatus(StrEnum):
+    """
+    A human's verdict, on a formalization, a theorem, or an edge.
+
+    Edges carry this too: an edge is itself an authored claim ("this code is
+    what stands in for that hypothesis"), and its severity is disputable.
+    """
+
+    DRAFT = 'draft'
+    WIP = 'wip'
+    SELF_ASSESSED = 'self-assessed'
+    EXPERT_REVIEWED = 'expert-reviewed'
+    ACCEPTED = 'accepted'
+    DISPUTED = 'disputed'
+    REJECTED = 'rejected'
+
+
+class Freshness(StrEnum):
+    """Whether a reference still resolves against the pinned formalization."""
+
+    #: Resolves, at the recorded commit.
+    CURRENT = 'current'
+
+    #: The formalization moved since the reference was drawn.
+    STALE = 'stale'
+
+    #: The declaration or binder no longer exists.
+    BROKEN = 'broken'
+
+    #: Not checked.
+    UNKNOWN = 'unknown'
+
+
+@dataclass(frozen=True)
+class HypothesisRef:
+    """
+    A parsed ``Declaration::binder`` reference.
+
+    References are strings on purpose. The object form was checked at import
+    time, which meant the check only ran if the annotated module imported
+    cleanly -- no good for auditing a repository whose dependencies you cannot
+    install. A string is extractable from source without executing anything, and
+    the linter does the same check statically.
+    """
+
+    declaration: str
+    hypothesis: str | None = None
+
+    @property
+    def key(self) -> str:
+        if self.hypothesis is None:
+            return self.declaration
+        return f'{self.declaration}{REF_SEPARATOR}{self.hypothesis}'
+
+    def __str__(self) -> str:
+        return self.key
+
+
+def parse_ref(ref) -> HypothesisRef:
+    """
+    Coerce a reference to a :class:`HypothesisRef`.
+
+    Accepts the string form, an already-parsed ref, or a :class:`Hypothesis`
+    object -- so code that has a real formalization loaded can keep passing
+    objects while the extractor reads strings out of the same source.
+
+    Example:
+        >>> parse_ref('Paper.main::hcover').hypothesis
+        'hcover'
+        >>> parse_ref('Paper.main').hypothesis is None
+        True
+    """
+    if isinstance(ref, HypothesisRef):
+        return ref
+    if isinstance(ref, Hypothesis):
+        return HypothesisRef(declaration=ref.declaration, hypothesis=ref.name)
+    if isinstance(ref, Theorem):
+        return HypothesisRef(declaration=ref.declaration)
+    if isinstance(ref, str):
+        declaration, sep, hypothesis = ref.partition(REF_SEPARATOR)
+        return HypothesisRef(declaration=declaration, hypothesis=hypothesis if sep else None)
+    raise TypeError(f'cannot interpret {ref!r} as a hypothesis reference')
+
+
+@dataclass(frozen=True)
+class Hypothesis:
+    """
+    One named assumption of a theorem.
+
+    ``name`` is the binder as it appears in the statement (``hgap``,
+    ``hcompetitive``, ``fit``). Binder names are what make an edge stable:
+    they survive the refactors that invalidate file and line, as the DKPS
+    library demonstrated by moving every one of its files in five weeks while
+    keeping every binder.
+
+    ``structural`` marks a binder that supplies an *object* rather than a
+    proposition -- the estimator, the embedding, the baseline. Those are still
+    assumptions in the sense that matters here (the theorem is about *that*
+    object and the code might use another), so they get edges, but they read
+    differently in a report.
+    """
+
+    name: str
+    informal: str = ''
+    lean: str | None = None
+    structural: bool = False
+    declaration: str | None = None  # owning theorem; set by Theorem
+
+    @property
+    def key(self) -> str:
+        if self.declaration:
+            return f'{self.declaration}{REF_SEPARATOR}{self.name}'
+        return self.name
+
+    @property
+    def ref(self) -> HypothesisRef:
+        return HypothesisRef(declaration=self.declaration, hypothesis=self.name)
+
+    def __str__(self) -> str:
+        return self.key
+
+
+@dataclass(frozen=True)
+class Theorem:
+    """
+    A statement, referenced by fully-qualified declaration name.
+
+    Note "statement", not "proved theorem". A card whose team has no
+    formalization still gets one -- conclusion plus named hypotheses, with
+    ``proof=SORRY``. The statement is the schema for the assumption ledger, and
+    writing it is the forcing function: you cannot state it without naming the
+    hypotheses, and naming them is most of the value.
+    """
+
+    declaration: str
+    informal: str = ''
+    conclusion: str = ''
+    hypotheses: tuple[Hypothesis, ...] = ()
+    axioms: tuple[str, ...] | None = None
+    file: str | None = None
+    line: int | None = None
+    review: ReviewStatus = ReviewStatus.DRAFT
+    note: str = ''
+
+    def __init__(
+        self,
+        declaration: str,
+        informal: str = '',
+        conclusion: str = '',
+        hypotheses: Iterable['Hypothesis | str'] = (),
+        axioms: Iterable[str] | None = None,
+        file: str | None = None,
+        line: int | None = None,
+        review: ReviewStatus | str = ReviewStatus.DRAFT,
+        note: str = '',
+    ) -> None:
+        bound = []
+        for hyp in hypotheses:
+            if isinstance(hyp, str):
+                hyp = Hypothesis(name=hyp)
+            bound.append(
+                Hypothesis(
+                    name=hyp.name,
+                    informal=hyp.informal,
+                    lean=hyp.lean,
+                    structural=hyp.structural,
+                    declaration=declaration,
+                )
+            )
+        object.__setattr__(self, 'declaration', declaration)
+        object.__setattr__(self, 'informal', informal)
+        object.__setattr__(self, 'conclusion', conclusion)
+        object.__setattr__(self, 'hypotheses', tuple(bound))
+        object.__setattr__(self, 'axioms', None if axioms is None else tuple(axioms))
+        object.__setattr__(self, 'file', file)
+        object.__setattr__(self, 'line', line)
+        object.__setattr__(self, 'review', ReviewStatus(review))
+        object.__setattr__(self, 'note', note)
+
+    @property
+    def name(self) -> str:
+        """The final component of the declaration."""
+        return self.declaration.rsplit('.', 1)[-1]
+
+    @property
+    def hypotheses_enumerated(self) -> bool:
+        """
+        Whether the hypothesis list is known at all.
+
+        Empty means *not enumerated*, never *has none*. A manifest names
+        capstones without their binders, and reporting such a theorem as fully
+        covered would let a missing exporter pass for a clean bill of health.
+        """
+        return bool(self.hypotheses)
+
+    @property
+    def proof(self) -> ProofStatus:
+        """
+        The kernel's verdict.
+
+        Example:
+            >>> Theorem('A', axioms=['propext']).proof
+            <ProofStatus.PROVED: 'proved'>
+            >>> Theorem('A', axioms=['sorryAx']).proof
+            <ProofStatus.SORRY: 'sorry'>
+            >>> Theorem('A').proof
+            <ProofStatus.UNKNOWN: 'unknown'>
+        """
+        if self.axioms is None:
+            return ProofStatus.UNKNOWN
+        if set(self.axioms) <= KERNEL_AXIOMS:
+            return ProofStatus.PROVED
+        return ProofStatus.SORRY
+
+    @property
+    def extra_axioms(self) -> tuple[str, ...]:
+        """Axioms used beyond the kernel's."""
+        if self.axioms is None:
+            return ()
+        return tuple(a for a in self.axioms if a not in KERNEL_AXIOMS)
+
+    def hypothesis(self, name: str) -> Hypothesis:
+        """
+        Look up a hypothesis by binder name.
+
+        Raises if the hypotheses are enumerated and ``name`` is not among them.
+        If they are not enumerated the hypothesis is created on demand, and
+        coverage over this theorem stays "unknown".
+
+        Example:
+            >>> Theorem('A', hypotheses=['hgap'])['hgap'].key
+            'A::hgap'
+            >>> Theorem('A', hypotheses=['hgap'])['hgep']
+            Traceback (most recent call last):
+              ...
+            KeyError: "theorem 'A' has no hypothesis 'hgep'; known: hgap"
+        """
+        for hyp in self.hypotheses:
+            if hyp.name == name:
+                return hyp
+        if self.hypotheses_enumerated:
+            known = ', '.join(h.name for h in self.hypotheses)
+            raise KeyError(f'theorem {self.declaration!r} has no hypothesis {name!r}; known: {known}')
+        return Hypothesis(name=name, declaration=self.declaration)
+
+    def __getitem__(self, name: str) -> Hypothesis:
+        return self.hypothesis(name)
+
+    def to_dict(self) -> dict:
+        out = {
+            'declaration': self.declaration,
+            'informal': self.informal,
+            'conclusion': self.conclusion,
+            'proof': str(self.proof),
+            'review': str(self.review),
+            'axioms': list(self.axioms) if self.axioms is not None else None,
+            'file': self.file,
+            'line': self.line,
+            'hypotheses': [
+                {
+                    'name': h.name,
+                    'informal': h.informal,
+                    'lean': h.lean,
+                    'structural': h.structural,
+                }
+                for h in self.hypotheses
+            ],
+        }
+        if self.note:
+            out['note'] = self.note
+        return out
+
+    def __str__(self) -> str:
+        return self.declaration
+
+
+@dataclass
+class Formalization:
+    """
+    A body of statements -- typically one repository at one commit.
+
+    Pinning ``commit`` is what makes :class:`Freshness` computable. An edge
+    drawn against a moving formalization is an edge that quietly stops meaning
+    what it said, which is not hypothetical: every file and line in the first
+    hand-drawn DKPS edge table was invalid five weeks later.
+    """
+
+    name: str
+    repository: str | None = None
+    commit: str | None = None
+    source: str | None = None
+    review: ReviewStatus = ReviewStatus.DRAFT
+    note: str = ''
+    theorems: dict[str, Theorem] = field(default_factory=dict)
+
+    def __init__(
+        self,
+        name: str,
+        repository: str | None = None,
+        commit: str | None = None,
+        source: str | None = None,
+        review: ReviewStatus | str = ReviewStatus.DRAFT,
+        note: str = '',
+        theorems: 'Iterable[Theorem] | dict[str, Theorem]' = (),
+    ) -> None:
+        self.name = name
+        self.repository = repository
+        self.commit = commit
+        self.source = source
+        self.review = ReviewStatus(review)
+        self.note = note
+        if isinstance(theorems, dict):
+            self.theorems = dict(theorems)
+        else:
+            self.theorems = {t.declaration: t for t in theorems}
+
+    def add(self, theorem: Theorem) -> Theorem:
+        self.theorems[theorem.declaration] = theorem
+        return theorem
+
+    def theorem(self, declaration: str) -> Theorem:
+        """Look up by declaration name, suggesting near misses on a failure."""
+        try:
+            return self.theorems[declaration]
+        except KeyError:
+            import difflib
+
+            close = difflib.get_close_matches(declaration, self.theorems, n=3, cutoff=0.4)
+            hint = f'; did you mean {", ".join(close)}' if close else ''
+            raise KeyError(
+                f'{self.name!r} has no theorem {declaration!r} ({len(self.theorems)} known){hint}'
+            ) from None
+
+    def resolve(self, ref) -> 'Hypothesis | Theorem':
+        """
+        Resolve a reference to the object it names.
+
+        Raises :class:`KeyError` if the declaration or binder is absent -- which
+        is what the linter reports as :attr:`Freshness.BROKEN`.
+        """
+        parsed = parse_ref(ref)
+        theorem = self.theorem(parsed.declaration)
+        if parsed.hypothesis is None:
+            return theorem
+        return theorem.hypothesis(parsed.hypothesis)
+
+    def __getitem__(self, key: str) -> Theorem:
+        return self.theorem(key)
+
+    def __contains__(self, declaration: object) -> bool:
+        return declaration in self.theorems
+
+    def __iter__(self) -> Iterator[Theorem]:
+        return iter(self.theorems.values())
+
+    def __len__(self) -> int:
+        return len(self.theorems)
+
+    def to_dict(self) -> dict:
+        return {
+            'version': 1,
+            'project': {
+                'name': self.name,
+                'repository': self.repository,
+                'commit': self.commit,
+                'review': str(self.review),
+                'note': self.note,
+            },
+            'theorems': [t.to_dict() for t in self],
+        }
+
+
+@dataclass(frozen=True)
+class CodeSite:
+    """Where in the empirical codebase a relation was declared."""
+
+    module: str | None = None
+    qualname: str | None = None
+    file: str | None = None
+    line: int | None = None
+
+    @classmethod
+    def from_object(cls, obj) -> 'CodeSite':
+        """Best-effort location of a function, method, or class."""
+        import inspect
+
+        try:
+            file = inspect.getsourcefile(obj)
+            _, line = inspect.getsourcelines(obj)
+        except (TypeError, OSError):
+            file, line = None, None
+        return cls(
+            module=getattr(obj, '__module__', None),
+            qualname=getattr(obj, '__qualname__', None) or getattr(obj, '__name__', None),
+            file=file,
+            line=line,
+        )
+
+    @classmethod
+    def from_caller(cls, depth: int = 2) -> 'CodeSite':
+        """Location of the frame ``depth`` levels up -- used by ``with`` entry."""
+        import inspect
+
+        frame = inspect.currentframe()
+        try:
+            for _ in range(depth):
+                if frame is None:
+                    break
+                frame = frame.f_back
+            if frame is None:
+                return cls()
+            return cls(
+                module=frame.f_globals.get('__name__'),
+                qualname=frame.f_code.co_qualname,
+                file=frame.f_code.co_filename,
+                line=frame.f_lineno,
+            )
+        finally:
+            del frame
+
+    @classmethod
+    def parse(cls, text: str) -> 'CodeSite':
+        """
+        Parse the ``module.qualname:line`` form used in declared edges.
+
+        Example:
+            >>> CodeSite.parse('pkg.mod.Class.method:234').line
+            234
+        """
+        base, sep, line = text.rpartition(':')
+        if not sep or not line.isdigit():
+            base, line = text, None
+        module, _, qualname = base.partition('::')
+        if not qualname:
+            module, qualname = None, base
+        return cls(
+            module=module,
+            qualname=qualname,
+            line=int(line) if line else None,
+        )
+
+    def __str__(self) -> str:
+        if self.qualname and self.module and not self.qualname.startswith(self.module):
+            base = f'{self.module}.{self.qualname}'
+        else:
+            base = self.qualname or self.module or self.file or '<unlocated>'
+        return f'{base}:{self.line}' if self.line else base
+
+    def to_dict(self) -> dict:
+        return {
+            'module': self.module,
+            'qualname': self.qualname,
+            'file': self.file,
+            'line': self.line,
+        }
+
+
+@dataclass
+class Observation:
+    """
+    One runtime activation of an edge, with whatever values it witnessed.
+
+    The witness is the point. An edge that says "fixed pool, no density" is
+    prose; one that says ``num_example_runs=64, max_nn_distance=0.31`` is a
+    number you can put on an axis and watch across runs.
+    """
+
+    witness: dict = field(default_factory=dict)
+    check: 'Check | None' = None
+
+    def to_dict(self) -> dict:
+        return {
+            'witness': _jsonable(self.witness),
+            'check': self.check.to_dict() if self.check else None,
+        }
+
+
+@dataclass
+class Check:
+    """
+    The result of testing a hypothesis at run time.
+
+    Returned by a function decorated with :func:`~magnet.theory.predicates.checks`.
+    A check that comes back false is not a missing annotation -- it is a measured
+    contradiction between the run and the theorem the card claims to shadow.
+    """
+
+    ok: bool
+    value: object = None
+    detail: str = ''
+
+    def to_dict(self) -> dict:
+        return {'ok': self.ok, 'value': _jsonable(self.value), 'detail': self.detail}
+
+
+def _jsonable(value):
+    """
+    Reduce a value to something a card can serialize.
+
+    Witnessed values are arbitrary -- arrays, fitted models, benchmark suite
+    handles. Anything not obviously representable is summarized by its type
+    rather than dropped, so the record shows that something was witnessed even
+    when it cannot show what.
+    """
+    import json
+
+    if isinstance(value, (int, float, str, bool, type(None))):
+        return value
+    if isinstance(value, dict):
+        return {str(k): _jsonable(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_jsonable(v) for v in value]
+    try:
+        json.dumps(value)
+        return value
+    except (TypeError, ValueError):
+        return f'<{type(value).__name__}>'
+
+
+def severity_rank(severity: Severity) -> int:
+    """Order severities so ``max`` works on them."""
+    return {
+        Severity.NONE: 0,
+        Severity.LOW: 1,
+        Severity.MEDIUM: 2,
+        Severity.HIGH: 3,
+    }[Severity(severity)]
+
+
+def max_severity(severities: Sequence[Severity]) -> Severity:
+    if not severities:
+        return Severity.NONE
+    return max(severities, key=severity_rank)

--- a/magnet/theory/predicates.py
+++ b/magnet/theory/predicates.py
@@ -1,0 +1,554 @@
+"""
+The predicates: how code stands with respect to an idealized hypothesis.
+
+Six verbs, one object. Each reads as a true sentence at the site it annotates::
+
+    satisfies     the experiment establishes it
+    approximates  the same object, in a finite or numerical version
+    substitutes   a *different* object stands in
+    assumes       relied on; nothing establishes or checks it
+    ignores       a side condition delimiting the regime, dropped
+    violates      known to fail -- ideally with proof, via ``evidence=``
+
+plus one that resolves at run time::
+
+    checks        tested during the run; comes out satisfied or violated
+
+Every one of them returns an :class:`Edge`, and an ``Edge`` activates three
+ways with identical registration semantics:
+
+.. code:: python
+
+    # (a) bare -- the gap is an *absence* of code, so there is no site
+    assumes('Paper.main::hlipschitz', informal='never tested')
+
+    # (b) decorator -- site is the decorated object; each call is an observation
+    @approximates('Paper.main::hcover', informal='fixed pool')
+    def __init__(self, num_example_runs=64): ...
+
+    # (c) context manager -- site is the with-statement, plus explicit witnesses
+    with substitutes('Paper.main::hpsi') as edge:
+        coords = embed(texts)
+        edge.witness(embedder='nomic-embed-text-v2-moe', dim=coords.shape[1])
+
+The edge is registered when the predicate is *called*, in all three forms, so
+the assumption ledger does not depend on a ``with`` block being reached. What
+activation adds is the site and the observations.
+
+The decorator form is defined as wrapping the body in the context manager, so
+the two cannot drift, and it witnesses the call's arguments automatically --
+which covers the case that actually recurs, a hyperparameter standing in for an
+idealized quantity.
+"""
+import functools
+import inspect
+
+from magnet.theory.model import (
+    RELATION_DEFAULT_SEVERITY,
+    Check,
+    CodeSite,
+    Freshness,
+    HypothesisRef,
+    Observation,
+    Relation,
+    ReviewStatus,
+    Severity,
+    parse_ref,
+)
+from magnet.theory.registry import REGISTRY
+
+__all__ = [
+    'Edge',
+    'Grounding',
+    'satisfies',
+    'approximates',
+    'substitutes',
+    'assumes',
+    'ignores',
+    'violates',
+    'checks',
+    'grounds',
+    'PREDICATE_NAMES',
+]
+
+#: Names the static extractor looks for. Kept next to the definitions so the
+#: two cannot fall out of step.
+PREDICATE_NAMES = frozenset(
+    {
+        'satisfies',
+        'approximates',
+        'substitutes',
+        'assumes',
+        'ignores',
+        'violates',
+        'checks',
+        'grounds',
+    }
+)
+
+
+class _Activatable:
+    """
+    Shared activation machinery: bare call, decorator, or context manager.
+
+    Subclasses supply the payload; this supplies the three ways to attach it to
+    code, and the guarantee that decorating a function means exactly running its
+    body inside the context manager.
+    """
+
+    site: CodeSite | None
+    observations: list
+
+    # ------------------------------------------------------------ decorator
+
+    def __call__(self, obj):
+        self.site = CodeSite.from_object(obj)
+        _stamp(obj, self)
+
+        if not self.observe or not (inspect.isfunction(obj) or inspect.ismethod(obj)):
+            # Classes cannot have a body wrapped in a context manager, and
+            # observe=False is the escape hatch for hot paths. Annotate only.
+            return obj
+
+        signature = _signature_or_none(obj)
+
+        @functools.wraps(obj)
+        def wrapper(*args, **kwargs):
+            with self:
+                self.witness(**_bind(signature, args, kwargs, self.witness_params))
+                return obj(*args, **kwargs)
+
+        _stamp(wrapper, self)
+        return wrapper
+
+    # ------------------------------------------------------ context manager
+
+    def __enter__(self):
+        if self.site is None:
+            self.site = CodeSite.from_caller(depth=2)
+        self.observations.append(Observation())
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False  # never swallow
+
+    # ----------------------------------------------------------- witnessing
+
+    def witness(self, **values):
+        """
+        Record values observed during the current activation.
+
+        Outside an activation this is a no-op rather than an error: annotated
+        code should behave identically whether or not anyone is auditing it.
+        """
+        if values and self.observations:
+            self.observations[-1].witness.update(values)
+        return self
+
+    @property
+    def witnessed(self) -> dict:
+        """Merged witness across every activation, most recent winning."""
+        merged: dict = {}
+        for observation in self.observations:
+            merged.update(observation.witness)
+        return merged
+
+
+class Edge(_Activatable):
+    """
+    One hypothesis-to-code correspondence.
+
+    Constructed through the predicate verbs rather than directly, so the
+    relation is always set by the verb that reads correctly at the site.
+    """
+
+    def __init__(
+        self,
+        ref,
+        relation,
+        severity=None,
+        informal: str = '',
+        note: str = '',
+        evidence: str | None = None,
+        id: str | None = None,
+        review=ReviewStatus.DRAFT,
+        kind: str | None = None,
+        site=None,
+        observe: bool = True,
+        witness_params=None,
+        registry=None,
+    ) -> None:
+        self.ref: HypothesisRef = parse_ref(ref)
+        self.relation = Relation(relation)
+        self.severity = Severity(
+            severity if severity is not None else RELATION_DEFAULT_SEVERITY[self.relation]
+        )
+        self.informal = informal
+        self.note = note
+        #: For ``violates``: the declaration of a counterexample that proves it.
+        self.evidence = evidence
+        self.id = id
+        self.review = ReviewStatus(review)
+        #: Optional finer tag within a relation (``metric-swap`` vs
+        #: ``estimator-swap`` under ``substitutes``). Never carries the relation
+        #: itself -- that lesson is why the verb exists.
+        self.kind = kind
+        self.site = CodeSite.parse(site) if isinstance(site, str) else site
+        self.observe = observe
+        self.witness_params = tuple(witness_params) if witness_params else None
+        self.observations: list[Observation] = []
+        self.freshness = Freshness.UNKNOWN
+        (registry if registry is not None else REGISTRY).add_edge(self)
+
+    # ----------------------------------------------------------------- checks
+
+    def record_check(self, result) -> Check:
+        """Attach a :class:`Check` to the current activation."""
+        check = result if isinstance(result, Check) else Check(ok=bool(result), value=result)
+        if self.observations:
+            self.observations[-1].check = check
+        return check
+
+    @property
+    def check_outcome(self) -> str | None:
+        """``passed``, ``failed``, or ``not-run`` for a ``checks`` edge."""
+        if self.relation is not Relation.CHECKS:
+            return None
+        results = [o.check for o in self.observations if o.check is not None]
+        if not results:
+            return 'not-run'
+        return 'passed' if all(c.ok for c in results) else 'failed'
+
+    @property
+    def resolved_relation(self) -> Relation:
+        """
+        The relation to account with.
+
+        A ``checks`` edge is not a relation until it runs: passing resolves it
+        to ``satisfies``, failing to ``violates``, and never running leaves the
+        hypothesis merely assumed -- the state it was in before someone wrote
+        the checker.
+        """
+        if self.relation is not Relation.CHECKS:
+            return self.relation
+        return {
+            'passed': Relation.SATISFIES,
+            'failed': Relation.VIOLATES,
+            'not-run': Relation.ASSUMES,
+        }[self.check_outcome]
+
+    @property
+    def resolved_severity(self) -> Severity:
+        """A failed check is high severity regardless of what was declared."""
+        resolved = self.resolved_relation
+        if self.relation is Relation.CHECKS:
+            return RELATION_DEFAULT_SEVERITY[resolved]
+        return self.severity
+
+    # ------------------------------------------------------------- reporting
+
+    @property
+    def is_gap(self) -> bool:
+        return self.resolved_relation is not Relation.SATISFIES
+
+    def to_dict(self) -> dict:
+        return {
+            'id': self.id,
+            'hypothesis': self.ref.key,
+            'relation': str(self.relation),
+            'resolved_relation': str(self.resolved_relation),
+            'severity': str(self.resolved_severity),
+            'declared_severity': str(self.severity),
+            'kind': self.kind,
+            'review': str(self.review),
+            'freshness': str(self.freshness),
+            'site': str(self.site) if self.site else None,
+            'informal': self.informal,
+            'note': self.note,
+            'evidence': self.evidence,
+            'check_outcome': self.check_outcome,
+            'observations': [o.to_dict() for o in self.observations],
+            'witness': self.witnessed,
+        }
+
+    def __repr__(self) -> str:
+        where = f' at {self.site}' if self.site else ''
+        return f'<Edge {self.relation} {self.ref.key} [{self.resolved_severity}]{where}>'
+
+
+class Grounding(_Activatable):
+    """
+    A claim's assertion that it is the empirical shadow of a statement.
+
+    Separate from :class:`Edge` because it is a different axis: claim to
+    theorem, not code to hypothesis. Naming the theorem is what opens the card
+    up to an assumption audit, since it names the hypothesis list every edge
+    then has to account for.
+    """
+
+    def __init__(
+        self,
+        ref,
+        informal: str = '',
+        note: str = '',
+        formalization=None,
+        review=ReviewStatus.DRAFT,
+        site=None,
+        observe: bool = True,
+        witness_params=None,
+        registry=None,
+    ) -> None:
+        self.ref: HypothesisRef = parse_ref(ref)
+        self.informal = informal
+        self.note = note
+        self.formalization = formalization
+        self.review = ReviewStatus(review)
+        self.site = CodeSite.parse(site) if isinstance(site, str) else site
+        self.observe = observe
+        self.witness_params = tuple(witness_params) if witness_params else None
+        self.observations: list[Observation] = []
+        self.freshness = Freshness.UNKNOWN
+        (registry if registry is not None else REGISTRY).add_grounding(self)
+
+    @property
+    def declaration(self) -> str:
+        return self.ref.declaration
+
+    def to_dict(self) -> dict:
+        return {
+            'theorem': self.ref.declaration,
+            'informal': self.informal,
+            'note': self.note,
+            'review': str(self.review),
+            'freshness': str(self.freshness),
+            'site': str(self.site) if self.site else None,
+            'witness': self.witnessed,
+        }
+
+    def __repr__(self) -> str:
+        return f'<Grounding {self.ref.declaration}>'
+
+
+class _CheckEdge(Edge):
+    """
+    An :class:`Edge` whose decorator form also captures the checker's result.
+
+    Everything else about it is an ordinary edge -- the bare and
+    context-manager forms behave identically, and inside a ``with`` block the
+    caller records the outcome with :meth:`Edge.record_check`.
+    """
+
+    def __call__(self, func):
+        wrapped = super().__call__(func)
+
+        @functools.wraps(func)
+        def runner(*args, **kwargs):
+            result = wrapped(*args, **kwargs)
+            self.record_check(result)
+            return result
+
+        _stamp(runner, self)
+        return runner
+
+
+def _stamp(obj, annotation) -> None:
+    """Attach the annotation to the object, for collection without a registry."""
+    attr = '__magnet_groundings__' if isinstance(annotation, Grounding) else '__magnet_edges__'
+    try:
+        setattr(obj, attr, getattr(obj, attr, ()) + (annotation,))
+    except AttributeError:
+        pass  # builtins and slotted objects; the registry still has it
+
+
+def _signature_or_none(func):
+    try:
+        return inspect.signature(func)
+    except (TypeError, ValueError):
+        return None
+
+
+def _bind(signature, args, kwargs, only) -> dict:
+    """
+    Auto-witness a call's arguments.
+
+    Only simple scalars are recorded. A witness exists to be read on a dashboard
+    and diffed across runs, so a dataframe or a benchmark-suite handle would be
+    noise; ``self`` is dropped for the same reason.
+    """
+    if signature is None:
+        return {}
+    try:
+        bound = signature.bind(*args, **kwargs)
+    except TypeError:
+        return {}
+    bound.apply_defaults()
+    out = {}
+    for name, value in bound.arguments.items():
+        if name in {'self', 'cls'}:
+            continue
+        if only is not None and name not in only:
+            continue
+        if isinstance(value, (int, float, str, bool, type(None))):
+            out[name] = value
+    return out
+
+
+def _predicate(relation: Relation):
+    """Build one verb. All of them differ only in the relation they assert."""
+
+    def verb(ref, severity=None, **kwargs) -> Edge:
+        return Edge(ref, relation=relation, severity=severity, **kwargs)
+
+    verb.__name__ = str(relation)
+    verb.__qualname__ = str(relation)
+    return verb
+
+
+satisfies = _predicate(Relation.SATISFIES)
+satisfies.__doc__ = """
+Declare that the experiment establishes the hypothesis.
+
+Recording this is what distinguishes "we checked" from "nobody looked" -- the
+difference between a discharged assumption and one that merely never came up.
+
+Example:
+    >>> from magnet.theory import satisfies
+    >>> edge = satisfies('Paper.main::hbounded',
+    ...                  informal='scores are benchmark accuracies in [0, 1]')
+    >>> edge.is_gap
+    False
+"""
+
+approximates = _predicate(Relation.APPROXIMATES)
+approximates.__doc__ = """
+Declare that the code uses a finite or numerical version of the same object.
+
+The asymptotic hypothesis met with one finite draw; the density hypothesis met
+with a fixed pool.
+
+Example:
+    >>> from magnet.theory import approximates
+    >>> @approximates('Paper.main::hcover', informal='fixed pool, no density')
+    ... def build_pool(num_example_runs=64):
+    ...     return list(range(num_example_runs))
+    >>> _ = build_pool()
+    >>> build_pool.__magnet_edges__[0].witnessed
+    {'num_example_runs': 64}
+"""
+
+substitutes = _predicate(Relation.SUBSTITUTES)
+substitutes.__doc__ = """
+Declare that a *different* object stands in for the one the theorem is about.
+
+A different estimator, a different embedding, a different metric. Presumptively
+high severity, because the proved statement is then not about the artifact.
+
+Example:
+    >>> from magnet.theory import substitutes
+    >>> edge = substitutes('Paper.main::hmetric', kind='metric-swap',
+    ...                    informal='card reports MAE; the theorem controls MSE')
+    >>> edge.severity
+    <Severity.HIGH: 'high'>
+"""
+
+assumes = _predicate(Relation.ASSUMES)
+assumes.__doc__ = """
+Declare that the hypothesis is relied on and never established.
+
+The gap here is an *absence* of code, which is why the bare form matters: there
+is no line to decorate. Each of these is also a work item -- write a
+:func:`checks` for it and the relation stops being an assumption.
+
+Example:
+    >>> from magnet.theory import assumes
+    >>> edge = assumes('Paper.main::hlipschitz',
+    ...                informal='close-in-embedding implies close-in-score; never tested')
+    >>> edge.site is None
+    True
+"""
+
+ignores = _predicate(Relation.IGNORES)
+ignores.__doc__ = """
+Declare that a side condition delimiting the theorem's regime is dropped.
+
+Distinct from :func:`assumes` in that the condition is typically checkable and
+simply is not checked -- a numeric smallness bound, a rank condition.
+
+Example:
+    >>> from magnet.theory import ignores
+    >>> edge = ignores('Paper.main::hsmall', informal='no smallness check at this budget')
+    >>> str(edge.relation)
+    'ignores'
+"""
+
+violates = _predicate(Relation.VIOLATES)
+violates.__doc__ = """
+Declare that the hypothesis is known to fail.
+
+Pass ``evidence`` naming a proved counterexample where one exists. That is the
+difference between "we suspect this does not hold" and "it is proved that it
+does not", and only the second can be checked by someone else.
+
+Example:
+    >>> from magnet.theory import violates
+    >>> edge = violates('Paper.main::haffine',
+    ...                 evidence='Paper.OLS.lipschitz_not_sufficient_for_affineRealizability')
+    >>> edge.severity
+    <Severity.HIGH: 'high'>
+"""
+
+
+def checks(ref, severity=None, **kwargs) -> Edge:
+    """
+    Test a hypothesis at run time.
+
+    The decorated function returns a :class:`~magnet.theory.model.Check` (or
+    anything truthy) and its result is recorded against the hypothesis. The
+    relation is then *computed* rather than declared: a passing check resolves
+    to ``satisfies``, a failing one to ``violates``, and a checker that never
+    ran leaves the hypothesis assumed.
+
+    A failing check is not a missing annotation. It is a measured contradiction
+    between the run and the theorem the card claims to shadow.
+
+    Example:
+        >>> from magnet.theory import checks
+        >>> from magnet.theory.model import Check
+        >>> @checks('Paper.main::hrank', informal='truncation rank within budget')
+        ... def rank_within_budget(rank, budget):
+        ...     return Check(ok=rank <= budget, value=rank,
+        ...                  detail=f'rank {rank} vs budget {budget}')
+        >>> _ = rank_within_budget(7, 8)
+        >>> edge = rank_within_budget.__magnet_edges__[0]
+        >>> edge.check_outcome
+        'passed'
+        >>> edge.resolved_relation
+        <Relation.SATISFIES: 'satisfies'>
+        >>> _ = rank_within_budget(9, 8)
+        >>> edge.check_outcome, edge.resolved_relation
+        ('failed', <Relation.VIOLATES: 'violates'>)
+    """
+    return _CheckEdge(ref, relation=Relation.CHECKS, severity=severity, **kwargs)
+
+
+def grounds(ref, **kwargs) -> Grounding:
+    """
+    Declare that a claim is the empirical shadow of a statement.
+
+    Args:
+        ref: the declaration the claim shadows.
+        informal: how the claim corresponds to the conclusion.
+        note: caveats about the correspondence itself.
+        formalization: the body it came from, for provenance.
+        review: this correspondence is itself an authored claim.
+
+    Example:
+        >>> from magnet.theory import grounds
+        >>> @grounds('Paper.TheoryPractice.EmpiricalCrossBudgetMAEClaim',
+        ...          informal='the card asserts exactly this proposition at n=32')
+        ... def claim(results):
+        ...     assert results['a'] <= results['b']
+        >>> claim.__magnet_groundings__[0].declaration
+        'Paper.TheoryPractice.EmpiricalCrossBudgetMAEClaim'
+    """
+    return Grounding(ref, **kwargs)

--- a/magnet/theory/predicates.py
+++ b/magnet/theory/predicates.py
@@ -174,6 +174,7 @@ class Edge(_Activatable):
         review=ReviewStatus.DRAFT,
         kind: str | None = None,
         site=None,
+        anchor: str | None = None,
         observe: bool = True,
         witness_params=None,
         registry=None,
@@ -194,6 +195,11 @@ class Edge(_Activatable):
         #: itself -- that lesson is why the verb exists.
         self.kind = kind
         self.site = CodeSite.parse(site) if isinstance(site, str) else site
+        #: A literal expected on the referenced line. Only meaningful for an
+        #: edge declared away from its code site: the site is then a string,
+        #: and nothing about a string keeps it true. The anchor is what lets
+        #: `magnet.theory.static.check_sites` notice the line has moved.
+        self.anchor = anchor
         self.observe = observe
         self.witness_params = tuple(witness_params) if witness_params else None
         self.observations: list[Observation] = []
@@ -263,6 +269,7 @@ class Edge(_Activatable):
             'review': str(self.review),
             'freshness': str(self.freshness),
             'site': str(self.site) if self.site else None,
+            'anchor': self.anchor,
             'informal': self.informal,
             'note': self.note,
             'evidence': self.evidence,
@@ -294,6 +301,7 @@ class Grounding(_Activatable):
         formalization=None,
         review=ReviewStatus.DRAFT,
         site=None,
+        anchor: str | None = None,
         observe: bool = True,
         witness_params=None,
         registry=None,
@@ -301,6 +309,7 @@ class Grounding(_Activatable):
         self.ref: HypothesisRef = parse_ref(ref)
         self.informal = informal
         self.note = note
+        self.anchor = anchor
         self.formalization = formalization
         self.review = ReviewStatus(review)
         self.site = CodeSite.parse(site) if isinstance(site, str) else site
@@ -322,6 +331,7 @@ class Grounding(_Activatable):
             'review': str(self.review),
             'freshness': str(self.freshness),
             'site': str(self.site) if self.site else None,
+            'anchor': self.anchor,
             'witness': self.witnessed,
         }
 

--- a/magnet/theory/registry.py
+++ b/magnet/theory/registry.py
@@ -1,0 +1,64 @@
+"""
+Where declared edges and groundings accumulate at run time.
+
+A registry is needed because the relation usually is not declared in the card.
+The assumption about a predictor's estimator is relaxed in the predictor's
+source, one repository away from the YAML that claims the result. The predicate
+marks it there; the registry is how a card assembled elsewhere finds it.
+
+The registry is the *runtime* half. It only knows what has been imported, which
+is why it is not the authority on what a codebase declares --
+:mod:`magnet.theory.static` reads that from source without executing anything.
+Use the registry for what a *run* did: which edges activated, with what
+witnessed values, and how the checks came out.
+"""
+from typing import Iterator
+
+__all__ = ['TheoryRegistry', 'REGISTRY']
+
+
+class TheoryRegistry:
+    """Collection of everything the predicates have constructed."""
+
+    def __init__(self) -> None:
+        self.edges: list = []
+        self.groundings: list = []
+
+    def add_edge(self, edge):
+        self.edges.append(edge)
+        return edge
+
+    def add_grounding(self, grounding):
+        self.groundings.append(grounding)
+        return grounding
+
+    def edges_for(self, declaration: str) -> list:
+        """Every registered edge whose hypothesis belongs to ``declaration``."""
+        return [e for e in self.edges if e.ref.declaration == declaration]
+
+    def observed(self) -> list:
+        """Edges that actually activated during this run."""
+        return [e for e in self.edges if e.observations]
+
+    def declared_but_unobserved(self) -> list:
+        """
+        Edges that never activated.
+
+        A branch not taken. The ledger does not describe what executed, which is
+        worth surfacing even though it is not an error.
+        """
+        return [e for e in self.edges if e.site is not None and not e.observations]
+
+    def clear(self) -> None:
+        self.edges.clear()
+        self.groundings.clear()
+
+    def __iter__(self) -> Iterator:
+        return iter(self.edges)
+
+    def __len__(self) -> int:
+        return len(self.edges)
+
+
+#: The default registry the predicates write to.
+REGISTRY = TheoryRegistry()

--- a/magnet/theory/shim.py
+++ b/magnet/theory/shim.py
@@ -1,0 +1,204 @@
+"""
+A dependency-free stand-in for the theory predicates.
+
+Copy this file into your own repository as ``magnet_theory.py`` and annotate
+your code with it. Every predicate here is a no-op: it returns its target
+unchanged, works as a decorator, a context manager, or a bare call, and imports
+nothing beyond the standard library. Your code runs identically whether or not
+anyone is auditing it, and you take on no dependency to describe your own
+assumptions.
+
+The annotations are read from your **source**, not from your imports, so none
+of this has to execute for the assumptions to be collected.
+
+To install a copy::
+
+    python -m magnet.theory.shim --install path/to/your/repo/magnet_theory.py
+
+Usage is the same as the real package::
+
+    from magnet_theory import approximates, assumes, grounds, substitutes
+
+    # (a) bare -- for a gap that is an *absence* of code
+    assumes('Paper.main::hlipschitz', severity='high',
+            informal='score smoothness is assumed and never tested')
+
+    # (b) decorator -- on the code that does it
+    @approximates('Paper.main::hcover', informal='fixed pool; theory needs density')
+    def __init__(self, num_example_runs=64): ...
+
+    # (c) context manager -- around a region, with values recorded
+    with substitutes('Paper.main::hpsi', kind='different-object') as edge:
+        coords = embed(texts)
+        edge.witness(embedder='some-embedding-model')
+
+    # on the claim itself
+    @grounds('Paper.TheoryPractice.EmpiricalCrossBudgetMAEClaim')
+    def claim(results): ...
+
+The predicates, and what each asserts about the code it annotates:
+
+===============  =========================================================
+``satisfies``    the experiment establishes the hypothesis
+``approximates`` the same object, in a finite or numerical version
+``substitutes``  a *different* object stands in for the theorem's
+``assumes``      relied on; nothing establishes or checks it
+``ignores``      a side condition delimiting the regime, dropped
+``violates``     known to fail; pass ``evidence=`` if there is a proof
+``checks``       tested at run time; the decorated function returns the result
+``grounds``      this claim is the empirical shadow of that statement
+===============  =========================================================
+
+Reference strings are ``Declaration::binder`` -- the fully-qualified statement
+name and the hypothesis binder within it. Use binder names, not file and line:
+line numbers go stale within weeks, binders survive.
+"""
+import functools
+import inspect
+
+__all__ = [
+    'satisfies',
+    'approximates',
+    'substitutes',
+    'assumes',
+    'ignores',
+    'violates',
+    'checks',
+    'grounds',
+    'Check',
+    'Annotation',
+]
+
+PREDICATES = (
+    'satisfies',
+    'approximates',
+    'substitutes',
+    'assumes',
+    'ignores',
+    'violates',
+    'checks',
+    'grounds',
+)
+
+
+class Check(object):
+    """Result of a runtime hypothesis check. Inert here; recorded by MAGNET."""
+
+    __slots__ = ('ok', 'value', 'detail')
+
+    def __init__(self, ok, value=None, detail=''):
+        self.ok = bool(ok)
+        self.value = value
+        self.detail = detail
+
+    def __bool__(self):
+        return self.ok
+
+    def __repr__(self):
+        return 'Check(ok=%r, value=%r)' % (self.ok, self.value)
+
+
+class Annotation(object):
+    """
+    An inert annotation that activates three ways.
+
+    Deliberately does nothing. The real implementation records observations and
+    witnessed values; this one keeps the same shape so annotated code behaves
+    identically with either installed.
+    """
+
+    __slots__ = ('predicate', 'ref', 'options')
+
+    def __init__(self, predicate, ref, options):
+        self.predicate = predicate
+        self.ref = ref
+        self.options = options
+
+    # decorator
+    def __call__(self, obj):
+        if not (inspect.isfunction(obj) or inspect.ismethod(obj)):
+            return obj
+
+        @functools.wraps(obj)
+        def wrapper(*args, **kwargs):
+            return obj(*args, **kwargs)
+
+        return wrapper
+
+    # context manager
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def witness(self, **values):
+        """Record observed values. Inert here."""
+        return self
+
+    def record_check(self, result):
+        """Record a check result. Inert here."""
+        return result
+
+    def __repr__(self):
+        return '<%s %s>' % (self.predicate, self.ref)
+
+
+def _predicate(name):
+    def verb(ref, severity=None, **options):
+        if severity is not None:
+            options['severity'] = severity
+        return Annotation(name, ref, options)
+
+    verb.__name__ = name
+    verb.__qualname__ = name
+    verb.__doc__ = 'Inert %r annotation; see the module docstring.' % (name,)
+    return verb
+
+
+satisfies = _predicate('satisfies')
+approximates = _predicate('approximates')
+substitutes = _predicate('substitutes')
+assumes = _predicate('assumes')
+ignores = _predicate('ignores')
+violates = _predicate('violates')
+checks = _predicate('checks')
+grounds = _predicate('grounds')
+
+
+def _install(destination):
+    """Copy this file to ``destination``."""
+    import os
+    import shutil
+
+    source = os.path.abspath(__file__)
+    destination = os.path.abspath(destination)
+    if os.path.isdir(destination):
+        destination = os.path.join(destination, 'magnet_theory.py')
+    if source == destination:
+        raise ValueError('refusing to copy the shim over itself')
+    shutil.copyfile(source, destination)
+    return destination
+
+
+def _main(argv=None):
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        prog='python -m magnet.theory.shim',
+        description='Install the dependency-free theory-annotation shim.',
+    )
+    parser.add_argument(
+        '--install',
+        metavar='PATH',
+        help='destination file or directory; a directory gets magnet_theory.py',
+    )
+    args = parser.parse_args(argv)
+    if args.install:
+        print('Wrote %s' % (_install(args.install),))
+    else:
+        parser.print_help()
+
+
+if __name__ == '__main__':
+    _main()

--- a/magnet/theory/static.py
+++ b/magnet/theory/static.py
@@ -1,0 +1,630 @@
+"""
+Reading the assumption ledger out of source, without executing it.
+
+The runtime registry only knows what has been imported, which makes it the
+wrong authority on what a codebase declares. Teams annotate repositories whose
+dependencies we cannot always install, in environments where importing their
+predictor would pull in a serving stack. And an annotation that lives behind an
+``if`` nobody took is still a declaration.
+
+So the ledger is extracted by parsing. This module finds every predicate call in
+a file or tree, in any of its four syntactic positions, resolves the hypothesis
+reference where it can, and *reports* what it cannot resolve rather than
+dropping it -- a team gets told "line 234 declares an edge we could not read",
+which is the whole point of doing this statically.
+
+The one API consequence: references should be **string literals**. The object
+form (``QE['hcover']``) was validated at import; a string is validated by
+:func:`lint` against a theorem index, which is the same check done earlier and
+without needing the code to run. Simple module-level bindings are resolved too,
+so an existing object-style codebase is not left out.
+
+Example:
+    >>> source = '''
+    ... from magnet.theory import approximates, assumes
+    ...
+    ... assumes('Paper.main::hlipschitz', informal='never tested')
+    ...
+    ... @approximates('Paper.main::hcover', severity='high')
+    ... def build_pool(num_example_runs=64):
+    ...     ...
+    ... '''
+    >>> ledger = extract_source(source, filename='predictor.py')
+    >>> for found in ledger.annotations:
+    ...     print(found.predicate, found.ref, found.form)
+    assumes Paper.main::hlipschitz bare
+    approximates Paper.main::hcover decorator
+    >>> ledger.annotations[1].options['severity']
+    'high'
+"""
+import ast
+from dataclasses import dataclass, field
+from typing import Iterable, Iterator, Sequence
+
+from magnet.theory.predicates import PREDICATE_NAMES
+
+__all__ = [
+    'ExtractedAnnotation',
+    'StaticLedger',
+    'Issue',
+    'extract_source',
+    'extract_file',
+    'extract_tree',
+    'lint',
+    'THEORY_MODULES',
+    'SKIP_DIRECTORIES',
+]
+
+#: Modules a predicate may be imported from. ``magnet_theory`` is the
+#: dependency-free shim teams vendor; both spell the same API.
+THEORY_MODULES = frozenset(
+    {
+        'magnet.theory',
+        'magnet.theory.predicates',
+        'magnet_theory',
+    }
+)
+
+SKIP_DIRECTORIES = frozenset(
+    {
+        '.git',
+        '.hg',
+        '.tox',
+        '.venv',
+        'venv',
+        '__pycache__',
+        'node_modules',
+        'build',
+        'dist',
+        '.mypy_cache',
+        '.pytest_cache',
+        '.ruff_cache',
+        'site-packages',
+    }
+)
+
+
+@dataclass
+class ExtractedAnnotation:
+    """One predicate call found in source."""
+
+    predicate: str
+    ref: str | None
+    ref_expr: str
+    form: str
+    file: str | None = None
+    line: int = 0
+    qualname: str = ''
+    target: str | None = None
+    options: dict = field(default_factory=dict)
+    unreadable_options: tuple[str, ...] = ()
+
+    @property
+    def resolved(self) -> bool:
+        return self.ref is not None
+
+    @property
+    def declaration(self) -> str | None:
+        if self.ref is None:
+            return None
+        return self.ref.split('::', 1)[0]
+
+    @property
+    def hypothesis(self) -> str | None:
+        if self.ref is None or '::' not in self.ref:
+            return None
+        return self.ref.split('::', 1)[1]
+
+    @property
+    def site(self) -> str:
+        where = self.qualname or '<module>'
+        return f'{where}:{self.line}'
+
+    def to_dict(self) -> dict:
+        return {
+            'predicate': self.predicate,
+            'ref': self.ref,
+            'ref_expr': self.ref_expr,
+            'resolved': self.resolved,
+            'form': self.form,
+            'file': self.file,
+            'line': self.line,
+            'qualname': self.qualname,
+            'target': self.target,
+            'options': self.options,
+            'unreadable_options': list(self.unreadable_options),
+        }
+
+
+@dataclass
+class StaticLedger:
+    """Everything a source tree declares about its relationship to theory."""
+
+    annotations: list[ExtractedAnnotation] = field(default_factory=list)
+    errors: list[tuple[str, str]] = field(default_factory=list)
+
+    @property
+    def edges(self) -> list[ExtractedAnnotation]:
+        return [a for a in self.annotations if a.predicate != 'grounds']
+
+    @property
+    def groundings(self) -> list[ExtractedAnnotation]:
+        return [a for a in self.annotations if a.predicate == 'grounds']
+
+    @property
+    def unresolved(self) -> list[ExtractedAnnotation]:
+        return [a for a in self.annotations if not a.resolved]
+
+    def declarations(self) -> set[str]:
+        return {a.declaration for a in self.annotations if a.declaration}
+
+    def extend(self, other: 'StaticLedger') -> 'StaticLedger':
+        self.annotations.extend(other.annotations)
+        self.errors.extend(other.errors)
+        return self
+
+    def to_dict(self) -> dict:
+        return {
+            'annotations': [a.to_dict() for a in self.annotations],
+            'errors': [{'file': f, 'error': e} for f, e in self.errors],
+        }
+
+    def __iter__(self) -> Iterator[ExtractedAnnotation]:
+        return iter(self.annotations)
+
+    def __len__(self) -> int:
+        return len(self.annotations)
+
+
+def extract_source(source: str, filename: str | None = None) -> StaticLedger:
+    """Extract from a source string."""
+    ledger = StaticLedger()
+    try:
+        tree = ast.parse(source, filename=filename or '<string>')
+    except SyntaxError as ex:
+        ledger.errors.append((filename or '<string>', f'SyntaxError: {ex}'))
+        return ledger
+
+    aliases = _predicate_aliases(tree)
+    if not aliases.names and not aliases.modules:
+        return ledger  # nothing here imports the API
+
+    bindings = _statement_bindings(tree)
+    parents = _parent_map(tree)
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        predicate = aliases.predicate_of(node.func)
+        if predicate is None:
+            continue
+        ledger.annotations.append(
+            _build(node, predicate, bindings, parents, filename)
+        )
+    ledger.annotations.sort(key=lambda a: a.line)
+    return ledger
+
+
+def extract_file(path) -> StaticLedger:
+    """Extract from one file."""
+    import ubelt as ub
+
+    path = ub.Path(path)
+    try:
+        source = path.read_text()
+    except (OSError, UnicodeDecodeError) as ex:
+        ledger = StaticLedger()
+        ledger.errors.append((str(path), f'{type(ex).__name__}: {ex}'))
+        return ledger
+    return extract_source(source, filename=str(path))
+
+
+def extract_tree(root, skip: Iterable[str] = SKIP_DIRECTORIES) -> StaticLedger:
+    """
+    Extract from every ``.py`` file under ``root``.
+
+    Skips the usual noise directories; a vendored dependency's annotations are
+    not the audited repository's declarations.
+    """
+    import ubelt as ub
+
+    root = ub.Path(root)
+    skip = set(skip)
+    ledger = StaticLedger()
+    if root.is_file():
+        return extract_file(root)
+    for path in sorted(root.rglob('*.py')):
+        if any(part in skip for part in path.parts):
+            continue
+        ledger.extend(extract_file(path))
+    return ledger
+
+
+# --------------------------------------------------------------------- issues
+
+
+@dataclass
+class Issue:
+    """One problem found by :func:`lint`."""
+
+    kind: str
+    message: str
+    annotation: ExtractedAnnotation | None = None
+
+    def __str__(self) -> str:
+        where = f'{self.annotation.file}:{self.annotation.line}: ' if self.annotation else ''
+        return f'{where}{self.kind}: {self.message}'
+
+    def to_dict(self) -> dict:
+        return {
+            'kind': self.kind,
+            'message': self.message,
+            'file': self.annotation.file if self.annotation else None,
+            'line': self.annotation.line if self.annotation else None,
+        }
+
+
+def lint(ledger: StaticLedger, formalizations: Sequence = ()) -> list[Issue]:
+    """
+    Check a ledger, optionally against loaded formalizations.
+
+    This is where the validation the object form used to do at import time
+    happens instead -- and it does more, because it can see a reference that
+    names a declaration which no longer exists, which no amount of importing
+    would reveal.
+
+    Without formalizations it still catches the errors that need no index:
+    unreadable references, edges that name a theorem but no binder, and
+    duplicate ids.
+    """
+    issues: list[Issue] = []
+
+    for path, error in ledger.errors:
+        issues.append(Issue('unparseable', f'{path}: {error}'))
+
+    for annotation in ledger.annotations:
+        if not annotation.resolved:
+            issues.append(
+                Issue(
+                    'unresolved-reference',
+                    f'cannot read the reference {annotation.ref_expr!r} statically; '
+                    f'use a string literal such as "Some.Declaration::binder"',
+                    annotation,
+                )
+            )
+            continue
+        if annotation.predicate != 'grounds' and annotation.hypothesis is None:
+            issues.append(
+                Issue(
+                    'missing-binder',
+                    f'{annotation.predicate}({annotation.ref!r}) names a statement but no '
+                    f'hypothesis; edges attach to a binder',
+                    annotation,
+                )
+            )
+
+    seen: dict[str, ExtractedAnnotation] = {}
+    for annotation in ledger.annotations:
+        identifier = annotation.options.get('id')
+        if not identifier:
+            continue
+        if identifier in seen:
+            issues.append(
+                Issue(
+                    'duplicate-id',
+                    f'id {identifier!r} is also used at '
+                    f'{seen[identifier].file}:{seen[identifier].line}',
+                    annotation,
+                )
+            )
+        else:
+            seen[identifier] = annotation
+
+    if formalizations:
+        issues.extend(_lint_against(ledger, formalizations))
+    return issues
+
+
+def _lint_against(ledger: StaticLedger, formalizations: Sequence) -> list[Issue]:
+    issues: list[Issue] = []
+    for annotation in ledger.annotations:
+        if not annotation.resolved:
+            continue
+        declaration = annotation.declaration
+        holder = next((f for f in formalizations if declaration in f), None)
+        if holder is None:
+            issues.append(
+                Issue(
+                    'unknown-declaration',
+                    f'{declaration!r} is not in any loaded formalization',
+                    annotation,
+                )
+            )
+            continue
+        theorem = holder[declaration]
+        binder = annotation.hypothesis
+        if binder is None or not theorem.hypotheses_enumerated:
+            continue
+        if binder not in {h.name for h in theorem.hypotheses}:
+            known = ', '.join(h.name for h in theorem.hypotheses)
+            issues.append(
+                Issue(
+                    'unknown-binder',
+                    f'{declaration} has no hypothesis {binder!r}; known: {known}',
+                    annotation,
+                )
+            )
+    return issues
+
+
+# ------------------------------------------------------------------ internals
+
+
+@dataclass
+class _Aliases:
+    """Local names under which the predicates are reachable in one module."""
+
+    names: dict = field(default_factory=dict)  # local name -> predicate
+    modules: set = field(default_factory=set)  # local name for a theory module
+
+    def predicate_of(self, func: ast.expr) -> str | None:
+        if isinstance(func, ast.Name):
+            return self.names.get(func.id)
+        if isinstance(func, ast.Attribute) and func.attr in PREDICATE_NAMES:
+            base = _dotted(func.value)
+            if base is not None and base in self.modules:
+                return func.attr
+        return None
+
+
+def _predicate_aliases(tree: ast.AST) -> _Aliases:
+    """
+    Map local names back to predicates.
+
+    Handles ``from magnet.theory import assumes``, ``... as skips``, and
+    ``import magnet.theory as th`` followed by ``th.assumes(...)``.
+    """
+    aliases = _Aliases()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            if node.module in THEORY_MODULES:
+                for alias in node.names:
+                    if alias.name in PREDICATE_NAMES:
+                        aliases.names[alias.asname or alias.name] = alias.name
+                    elif alias.name == 'predicates':
+                        aliases.modules.add(alias.asname or alias.name)
+            elif node.module and node.module.rsplit('.', 1)[0] in THEORY_MODULES:
+                for alias in node.names:
+                    if alias.name in PREDICATE_NAMES:
+                        aliases.names[alias.asname or alias.name] = alias.name
+        elif isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name in THEORY_MODULES:
+                    # `import magnet.theory` binds `magnet`; `as th` binds `th`.
+                    aliases.modules.add(alias.asname or alias.name)
+                    if alias.asname is None:
+                        aliases.modules.add(alias.name)
+    return aliases
+
+
+def _statement_bindings(tree: ast.AST) -> dict:
+    """
+    Resolve module-level names that hold a declaration.
+
+    Supports the object-style spellings that appear in code written before the
+    string form -- ``QE = DKPS['Some.Decl']`` and ``QE = DKPS.theorem('Some.Decl')``
+    -- so ``QE['hcover']`` can still be read out of source.
+    """
+    bindings: dict[str, str] = {}
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.Assign, ast.AnnAssign)):
+            continue
+        targets = node.targets if isinstance(node, ast.Assign) else [node.target]
+        value = node.value
+        if value is None:
+            continue
+        declaration = None
+        if isinstance(value, ast.Subscript) and isinstance(value.slice, ast.Constant):
+            if isinstance(value.slice.value, str):
+                declaration = value.slice.value
+        elif isinstance(value, ast.Call) and value.args:
+            func = value.func
+            name = func.attr if isinstance(func, ast.Attribute) else getattr(func, 'id', None)
+            if name in {'theorem', 'resolve', 'statement'}:
+                first = value.args[0]
+                if isinstance(first, ast.Constant) and isinstance(first.value, str):
+                    declaration = first.value
+        elif isinstance(value, ast.Constant) and isinstance(value.value, str):
+            declaration = value.value
+        if declaration is None:
+            continue
+        for target in targets:
+            if isinstance(target, ast.Name):
+                bindings[target.id] = declaration
+    return bindings
+
+
+def _build(
+    node: ast.Call,
+    predicate: str,
+    bindings: dict,
+    parents: dict,
+    filename: str | None,
+) -> ExtractedAnnotation:
+    ref_expr = ast.unparse(node.args[0]) if node.args else ''
+    ref = _resolve_ref(node.args[0], bindings) if node.args else None
+
+    options: dict = {}
+    unreadable: list[str] = []
+    # The first positional is the reference; the second, where given, is
+    # severity, matching the predicate signatures.
+    if len(node.args) > 1:
+        value, ok = _literal(node.args[1])
+        if ok:
+            options['severity'] = value
+    for keyword in node.keywords:
+        if keyword.arg is None:
+            unreadable.append('**kwargs')
+            continue
+        value, ok = _literal(keyword.value)
+        if ok:
+            options[keyword.arg] = value
+        else:
+            unreadable.append(keyword.arg)
+
+    form, target = _form_of(node, parents)
+    if ref is None and form == 'bare' and predicate == 'grounds':
+        pass  # a grounding may legitimately name only a declaration
+
+    return ExtractedAnnotation(
+        predicate=predicate,
+        ref=ref,
+        ref_expr=ref_expr,
+        form=form,
+        file=filename,
+        line=node.lineno,
+        qualname=_qualname(node, parents),
+        target=target,
+        options=options,
+        unreadable_options=tuple(unreadable),
+    )
+
+
+def _resolve_ref(node: ast.expr, bindings: dict) -> str | None:
+    """
+    Read a hypothesis reference out of an expression.
+
+    Handles the string literal; an f-string or ``+`` concatenation built from
+    module-level string constants, which is how anyone writing more than two
+    edges against a ninety-character declaration name will actually spell it;
+    the module-level binding subscripted by a binder name; and an explicit
+    ``.hypothesis('name')`` call. Anything else is left unresolved and reported.
+    """
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    if isinstance(node, (ast.JoinedStr, ast.BinOp, ast.Name)):
+        return _join_string(node, bindings)
+    if isinstance(node, ast.Subscript) and isinstance(node.slice, ast.Constant):
+        binder = node.slice.value
+        base = _dotted(node.value)
+        if isinstance(binder, str) and base is not None:
+            declaration = bindings.get(base)
+            if declaration is not None:
+                return f'{declaration}::{binder}'
+            # A direct `FORMALIZATION['Some.Decl']` names a statement, not a
+            # binder -- valid for `grounds`.
+            if '.' in binder:
+                return binder
+    if isinstance(node, ast.Call) and node.args:
+        func = node.func
+        if isinstance(func, ast.Attribute) and func.attr == 'hypothesis':
+            first = node.args[0]
+            base = _dotted(func.value)
+            if isinstance(first, ast.Constant) and isinstance(first.value, str) and base:
+                declaration = bindings.get(base)
+                if declaration is not None:
+                    return f'{declaration}::{first.value}'
+    return None
+
+
+def _join_string(node: ast.expr, bindings: dict) -> str | None:
+    """
+    Fold an f-string or ``+`` chain of string constants into one value.
+
+    Only constants and module-level names bound to string constants
+    participate; anything else makes the whole expression unresolvable, which is
+    the honest answer rather than a partial reference.
+
+    Example:
+        >>> tree = ast.parse("f'{DECL}::hgap'", mode='eval')
+        >>> _join_string(tree.body, {'DECL': 'Paper.main'})
+        'Paper.main::hgap'
+    """
+    if isinstance(node, ast.Constant):
+        return node.value if isinstance(node.value, str) else None
+    if isinstance(node, ast.Name):
+        return bindings.get(node.id)
+    if isinstance(node, ast.FormattedValue):
+        if node.format_spec is not None or node.conversion not in (-1, None):
+            return None
+        return _join_string(node.value, bindings)
+    if isinstance(node, ast.JoinedStr):
+        parts = [_join_string(v, bindings) for v in node.values]
+        return None if any(p is None for p in parts) else ''.join(parts)
+    if isinstance(node, ast.BinOp) and isinstance(node.op, ast.Add):
+        left = _join_string(node.left, bindings)
+        right = _join_string(node.right, bindings)
+        return None if left is None or right is None else left + right
+    return None
+
+
+def _literal(node: ast.expr):
+    """Evaluate a literal argument; ``(value, ok)``."""
+    try:
+        return ast.literal_eval(node), True
+    except (ValueError, SyntaxError, TypeError):
+        return None, False
+
+
+def _parent_map(tree: ast.AST) -> dict:
+    parents = {}
+    for node in ast.walk(tree):
+        for child in ast.iter_child_nodes(node):
+            parents[child] = node
+    return parents
+
+
+def _ancestors(node: ast.AST, parents: dict) -> Iterator[ast.AST]:
+    current = parents.get(node)
+    while current is not None:
+        yield current
+        current = parents.get(current)
+
+
+def _form_of(node: ast.Call, parents: dict) -> tuple[str, str | None]:
+    """
+    Which syntactic position the call occupies.
+
+    ``decorator``, ``with``, ``annotation``, or ``bare``. The distinction is
+    reported rather than normalized away because it tells a reader how the edge
+    behaves at run time -- whether it observes, and what it witnesses.
+    """
+    previous: ast.AST = node
+    for parent in _ancestors(node, parents):
+        if isinstance(parent, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            if any(previous is dec for dec in parent.decorator_list):
+                return 'decorator', parent.name
+            if isinstance(parent, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                if parent.returns is not None and previous is parent.returns:
+                    return 'annotation', parent.name
+            return 'bare', None
+        if isinstance(parent, ast.withitem):
+            return 'with', None
+        if isinstance(parent, ast.arg):
+            return 'annotation', parent.arg
+        if isinstance(parent, ast.AnnAssign):
+            if previous is parent.annotation:
+                name = parent.target.id if isinstance(parent.target, ast.Name) else None
+                return 'annotation', name
+            return 'bare', None
+        previous = parent
+    return 'bare', None
+
+
+def _qualname(node: ast.AST, parents: dict) -> str:
+    """Dotted names of the enclosing definitions, outermost first."""
+    names = []
+    for parent in _ancestors(node, parents):
+        if isinstance(parent, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            names.append(parent.name)
+    return '.'.join(reversed(names))
+
+
+def _dotted(node: ast.expr) -> str | None:
+    """Render a dotted name expression, or None if it is not one."""
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        base = _dotted(node.value)
+        return f'{base}.{node.attr}' if base else None
+    return None

--- a/magnet/theory/static.py
+++ b/magnet/theory/static.py
@@ -51,6 +51,7 @@ __all__ = [
     'extract_file',
     'extract_tree',
     'lint',
+    'check_sites',
     'THEORY_MODULES',
     'SKIP_DIRECTORIES',
 ]
@@ -323,6 +324,125 @@ def lint(ledger: StaticLedger, formalizations: Sequence = ()) -> list[Issue]:
     if formalizations:
         issues.extend(_lint_against(ledger, formalizations))
     return issues
+
+
+def check_sites(ledger: StaticLedger, roots: dict, repo_root='.') -> list[Issue]:
+    """
+    Verify that externally declared ``site=`` references still point at code.
+
+    An edge declared *at* its code site moves with the code. An edge declared
+    elsewhere carries a ``site=`` string instead, and nothing about a string
+    keeps it true -- which is the same rot that invalidated every ``file:line``
+    in the first hand-drawn edge table within five weeks. This is the check that
+    makes the external form survivable.
+
+    Three things are verified, in increasing strength:
+
+    * the module resolves to a file at all;
+    * the line number is inside that file;
+    * an ``anchor`` -- a literal expected on that line -- still matches.
+
+    Only the third actually detects a shifted line, so declare anchors on the
+    edges that matter. A site with no anchor is reported as unanchored rather
+    than passing silently, because "the line exists" is not evidence that it is
+    the right line.
+
+    Args:
+        ledger: extracted annotations.
+        roots: top-level package name -> directory holding it.
+        repo_root: base for relative root paths.
+
+    Example:
+        >>> import tempfile, pathlib
+        >>> d = pathlib.Path(tempfile.mkdtemp())
+        >>> (d / 'pkg').mkdir()
+        >>> _ = (d / 'pkg' / 'mod.py').write_text('a = 1\\nb = LinearRegression()\\n')
+        >>> ledger = extract_source(
+        ...     "from magnet.theory import assumes\\n"
+        ...     "assumes('P::h', site='pkg.mod:2', anchor='LinearRegression')\\n",
+        ...     filename='edges.py')
+        >>> check_sites(ledger, {'pkg': str(d)})
+        []
+    """
+    import ubelt as ub
+
+    issues: list[Issue] = []
+    for annotation in ledger.annotations:
+        site = annotation.options.get('site')
+        if not isinstance(site, str):
+            continue
+        base, _, line = site.rpartition(':')
+        if not base:
+            base, line = site, ''
+        parts = base.split('.')
+        root = roots.get(parts[0])
+        if root is None:
+            issues.append(
+                Issue('unknown-site-root', f'no source root for package {parts[0]!r}', annotation)
+            )
+            continue
+
+        # `roots` maps a package to the directory it lives *in*, so the package
+        # name stays part of the path.
+        path = _resolve_module(ub.Path(repo_root) / root, parts)
+        if path is None:
+            issues.append(
+                Issue('missing-site-file', f'{site!r} does not resolve to a file', annotation)
+            )
+            continue
+
+        if not line.isdigit():
+            continue  # a symbol reference, not a line; nothing to drift
+
+        number = int(line)
+        text = path.read_text().splitlines()
+        if not (0 < number <= len(text)):
+            issues.append(
+                Issue(
+                    'site-line-out-of-range',
+                    f'{path} has {len(text)} lines; {site!r} names line {number}',
+                    annotation,
+                )
+            )
+            continue
+
+        anchor = annotation.options.get('anchor')
+        if not isinstance(anchor, str):
+            issues.append(
+                Issue(
+                    'unanchored-site',
+                    f'{site!r} has no anchor, so a line shift would go unnoticed',
+                    annotation,
+                )
+            )
+        elif anchor not in text[number - 1]:
+            issues.append(
+                Issue(
+                    'anchor-mismatch',
+                    f'{site!r} expected {anchor!r} but line {number} is '
+                    f'{text[number - 1].strip()!r}',
+                    annotation,
+                )
+            )
+    return issues
+
+
+def _resolve_module(root, parts: Sequence[str]):
+    """
+    Find the file a dotted path names, longest prefix first.
+
+    Tries ``.py``, then ``.yaml``/``.yml`` -- evaluation cards are YAML and are
+    referenced through the same dotted convention -- then a package directory.
+    """
+    for n in range(len(parts), 0, -1):
+        stem = root.joinpath(*parts[:n])
+        for suffix in ('.py', '.yaml', '.yml'):
+            candidate = stem.with_suffix(suffix)
+            if candidate.exists():
+                return candidate
+        if (stem / '__init__.py').exists():
+            return stem / '__init__.py'
+    return None
 
 
 def _lint_against(ledger: StaticLedger, formalizations: Sequence) -> list[Issue]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,7 @@ dynamic.readme.file = [
 ]
 dynamic.readme.content-type = "text/markdown"
 dynamic.version.attr = "magnet.__version__"
-package-data.magnet = [ "cards/*.yaml" ]
+package-data.magnet = [ "cards/*.yaml", "theory/data/*.yaml" ]
 packages.find.namespaces = true
 packages.find.include = [ "magnet*" ]
 

--- a/tests/test_theory.py
+++ b/tests/test_theory.py
@@ -1,0 +1,410 @@
+"""
+Tests for the theory model, predicates, and coverage accounting.
+
+The behaviour worth protecting: a hypothesis nobody handled shows up as
+unaccounted, the three activation modes register identically, a checker that
+fails flips the relation, and a statement whose binders were never exported
+never reads as covered.
+"""
+import pytest
+
+from magnet.theory import (
+    Check,
+    Formalization,
+    Freshness,
+    Hypothesis,
+    ProofStatus,
+    Relation,
+    ReviewStatus,
+    Severity,
+    TheoreticalBasis,
+    TheoryRegistry,
+    Theorem,
+    approximates,
+    assumes,
+    checks,
+    grounds,
+    hygiene,
+    satisfies,
+    substitutes,
+    violates,
+)
+
+
+@pytest.fixture
+def registry():
+    return TheoryRegistry()
+
+
+@pytest.fixture
+def formalization():
+    return Formalization(
+        name='Example',
+        commit='deadbeef',
+        theorems=[
+            Theorem(
+                declaration='Paper.Section.main',
+                informal='The estimator converges.',
+                hypotheses=[
+                    Hypothesis('hiid', 'draws are iid'),
+                    Hypothesis('hvar', 'finite variance'),
+                    Hypothesis('hlim', 'n tends to infinity'),
+                    Hypothesis('psi', 'the true embedding', structural=True),
+                ],
+                axioms=['propext', 'Classical.choice', 'Quot.sound'],
+            )
+        ],
+    )
+
+
+def _basis(formalization, *annotations):
+    grounded = [a for a in annotations if a.__class__.__name__ == 'Grounding']
+    edges = [a for a in annotations if a.__class__.__name__ != 'Grounding']
+    return TheoreticalBasis.collect(
+        registry=None,
+        extra_groundings=grounded,
+        extra_edges=edges,
+        formalizations=[formalization],
+    )
+
+
+# ------------------------------------------------------------------- the model
+
+
+def test_hypothesis_keys_are_qualified(formalization):
+    assert formalization['Paper.Section.main']['hiid'].key == 'Paper.Section.main::hiid'
+
+
+def test_unknown_binder_is_an_error(formalization):
+    with pytest.raises(KeyError, match='has no hypothesis'):
+        formalization['Paper.Section.main']['h_typo']
+
+
+def test_unenumerated_statement_invents_binders_on_demand():
+    statement = Theorem('Paper.capstone')
+    assert not statement.hypotheses_enumerated
+    assert statement['anything'].key == 'Paper.capstone::anything'
+
+
+@pytest.mark.parametrize(
+    'axioms, status',
+    [
+        (['propext', 'Classical.choice', 'Quot.sound'], ProofStatus.PROVED),
+        (['propext'], ProofStatus.PROVED),
+        (['propext', 'sorryAx'], ProofStatus.SORRY),
+        (None, ProofStatus.UNKNOWN),
+    ],
+)
+def test_proof_status_tracks_the_axiom_set(axioms, status):
+    assert Theorem('A', axioms=axioms).proof is status
+
+
+def test_status_axes_are_independent():
+    # A statement can be proved, draft, and stale at once. Merging these into
+    # one indicator is the mistake this triple exists to prevent.
+    statement = Theorem('A', axioms=['propext'], review='draft')
+    assert statement.proof is ProofStatus.PROVED
+    assert statement.review is ReviewStatus.DRAFT
+
+
+def test_lookup_suggests_near_misses(formalization):
+    with pytest.raises(KeyError, match='did you mean'):
+        formalization['Paper.Section.mian']
+
+
+# --------------------------------------------------------------- the predicates
+
+
+def test_predicate_registers_when_called_not_when_activated(registry):
+    # The ledger must not depend on a code path being reached.
+    assumes('Paper.Section.main::hiid', registry=registry)
+    assert len(registry) == 1
+
+
+def test_bare_form_has_no_site(registry):
+    edge = assumes('Paper.Section.main::hiid', registry=registry)
+    assert edge.site is None
+    assert edge.relation is Relation.ASSUMES
+
+
+def test_decorator_form_records_site_and_witnesses_arguments(registry):
+    @approximates('Paper.Section.main::hlim', registry=registry)
+    def build_pool(num_example_runs=64, label='x'):
+        return num_example_runs
+
+    edge = build_pool.__magnet_edges__[0]
+    assert edge.site.qualname.endswith('build_pool')
+    assert not edge.observations
+
+    build_pool()
+    assert len(edge.observations) == 1
+    assert edge.witnessed == {'num_example_runs': 64, 'label': 'x'}
+
+    build_pool(32)
+    assert edge.witnessed['num_example_runs'] == 32
+
+
+def test_decorator_and_context_manager_agree(registry):
+    # Decorating a function is defined as running its body in the context
+    # manager, so the two must produce the same record.
+    @approximates('Paper.Section.main::hlim', registry=registry)
+    def decorated(n=8):
+        return n
+
+    decorated()
+
+    with approximates('Paper.Section.main::hlim', registry=registry) as edge:
+        edge.witness(n=8)
+
+    decorated_edge = decorated.__magnet_edges__[0]
+    assert len(decorated_edge.observations) == len(edge.observations) == 1
+    assert decorated_edge.witnessed == edge.witnessed == {'n': 8}
+    assert decorated_edge.relation is edge.relation
+
+
+def test_context_manager_locates_the_with_statement(registry):
+    with assumes('Paper.Section.main::hiid', registry=registry) as edge:
+        pass
+    assert edge.site is not None
+    assert edge.site.file.endswith('test_theory.py')
+
+
+def test_context_manager_does_not_swallow_exceptions(registry):
+    with pytest.raises(ValueError):
+        with assumes('Paper.Section.main::hiid', registry=registry):
+            raise ValueError('boom')
+
+
+def test_observe_false_skips_the_wrapper(registry):
+    @assumes('Paper.Section.main::hiid', observe=False, registry=registry)
+    def hot_path(n=1):
+        return n
+
+    hot_path()
+    assert hot_path.__magnet_edges__[0].observations == []
+
+
+def test_decorating_a_class_annotates_without_wrapping(registry):
+    @assumes('Paper.Section.main::hiid', registry=registry)
+    class Predictor:
+        pass
+
+    assert Predictor.__magnet_edges__[0].relation is Relation.ASSUMES
+    assert isinstance(Predictor, type)
+
+
+def test_severity_defaults_per_predicate(registry):
+    assert satisfies('A::h', registry=registry).severity is Severity.NONE
+    assert approximates('A::h', registry=registry).severity is Severity.MEDIUM
+    assert substitutes('A::h', registry=registry).severity is Severity.HIGH
+    assert violates('A::h', registry=registry).severity is Severity.HIGH
+
+
+def test_severity_can_be_overridden_positionally_or_by_keyword(registry):
+    assert approximates('A::h', 'high', registry=registry).severity is Severity.HIGH
+    assert approximates('A::h', severity='low', registry=registry).severity is Severity.LOW
+
+
+# -------------------------------------------------------------------- checks
+
+
+def test_passing_check_resolves_to_satisfies(registry):
+    @checks('Paper.Section.main::hvar', registry=registry)
+    def rank_ok(rank, budget):
+        return Check(ok=rank <= budget, value=rank)
+
+    rank_ok(7, 8)
+    edge = rank_ok.__magnet_edges__[0]
+    assert edge.check_outcome == 'passed'
+    assert edge.resolved_relation is Relation.SATISFIES
+    assert not edge.is_gap
+
+
+def test_failing_check_resolves_to_violates_at_high_severity(registry):
+    # A checker that runs and comes back false is a measured contradiction,
+    # not a missing annotation.
+    @checks('Paper.Section.main::hvar', registry=registry)
+    def rank_ok(rank, budget):
+        return Check(ok=rank <= budget, value=rank)
+
+    rank_ok(9, 8)
+    edge = rank_ok.__magnet_edges__[0]
+    assert edge.check_outcome == 'failed'
+    assert edge.resolved_relation is Relation.VIOLATES
+    assert edge.resolved_severity is Severity.HIGH
+
+
+def test_check_that_never_runs_leaves_the_hypothesis_assumed(registry):
+    @checks('Paper.Section.main::hvar', registry=registry)
+    def never_called():
+        return Check(ok=True)
+
+    edge = never_called.__magnet_edges__[0]
+    assert edge.check_outcome == 'not-run'
+    assert edge.resolved_relation is Relation.ASSUMES
+
+
+def test_check_returns_the_underlying_value(registry):
+    @checks('Paper.Section.main::hvar', registry=registry)
+    def compute():
+        return Check(ok=True, value=42)
+
+    assert compute().value == 42
+
+
+# ------------------------------------------------------------------- coverage
+
+
+def test_unaccounted_hypotheses_are_reported(formalization, registry):
+    basis = _basis(
+        formalization,
+        grounds('Paper.Section.main', registry=registry),
+        approximates('Paper.Section.main::hlim', 'high', registry=registry),
+        satisfies('Paper.Section.main::hvar', registry=registry),
+    )
+    coverage = basis.coverage()
+
+    assert not coverage.is_complete
+    assert sorted(h.name for h in coverage.unaccounted) == ['hiid', 'psi']
+    assert coverage.max_severity is Severity.HIGH
+    assert 'unaccounted' in coverage.summary()
+
+
+def test_complete_coverage(formalization, registry):
+    annotations = [grounds('Paper.Section.main', registry=registry)]
+    annotations += [
+        satisfies(f'Paper.Section.main::{name}', registry=registry)
+        for name in ('hiid', 'hvar', 'hlim', 'psi')
+    ]
+    coverage = _basis(formalization, *annotations).coverage()
+    assert coverage.is_complete
+    assert coverage.max_severity is Severity.NONE
+    assert coverage.summary() == 'standing on 4 assumptions: 4 discharged'
+
+
+def test_unenumerated_statement_never_reads_as_complete(registry):
+    # A statement whose binders nobody exported is not a covered one; letting
+    # it pass would make a missing exporter look like a clean bill of health.
+    formalization = Formalization(name='F', theorems=[Theorem('Paper.capstone')])
+    basis = _basis(formalization, grounds('Paper.capstone', registry=registry))
+    coverage = basis.coverage()
+    assert not coverage.is_complete
+    assert 'hypotheses not enumerated' in coverage.summary()
+
+
+def test_orphaned_edges_are_surfaced(formalization, registry):
+    basis = _basis(
+        formalization,
+        grounds('Paper.Section.main', registry=registry),
+        assumes('Paper.Section.main::h_renamed_upstream', registry=registry),
+    )
+    coverage = basis.coverage()
+    assert [e.ref.hypothesis for e in coverage.per_theorem[0].orphaned] == [
+        'h_renamed_upstream'
+    ]
+    assert not coverage.is_complete
+
+
+def test_dangling_edges_are_surfaced(formalization, registry):
+    # An edge naming a statement nothing is grounded on would otherwise vanish
+    # from the report with no explanation.
+    basis = _basis(
+        formalization,
+        grounds('Paper.Section.main', registry=registry),
+        assumes('Some.Other.Statement::hx', registry=registry),
+    )
+    coverage = basis.coverage()
+    assert [e.ref.key for e in coverage.dangling] == ['Some.Other.Statement::hx']
+    assert not coverage.is_complete
+    assert 'dangling' in coverage.summary()
+
+
+def test_failed_checks_are_collected(formalization, registry):
+    @checks('Paper.Section.main::hvar', registry=registry)
+    def failing():
+        return Check(ok=False, detail='rank exceeded budget')
+
+    failing()
+    basis = _basis(
+        formalization,
+        grounds('Paper.Section.main', registry=registry),
+        failing.__magnet_edges__[0],
+    )
+    assert len(basis.coverage().failed_checks) == 1
+
+
+def test_unproved_grounding_is_reported(registry):
+    formalization = Formalization(
+        name='F', theorems=[Theorem('Paper.shaky', axioms=['propext', 'sorryAx'])]
+    )
+    basis = _basis(formalization, grounds('Paper.shaky', registry=registry))
+    assert [t.declaration for t in basis.coverage().unproved] == ['Paper.shaky']
+
+
+def test_resolve_marks_broken_references(formalization, registry):
+    basis = _basis(
+        formalization,
+        grounds('Paper.Section.main', registry=registry),
+        assumes('Paper.Section.main::hiid', registry=registry),
+        assumes('Paper.Section.main::h_gone', registry=registry),
+    ).resolve()
+    freshness = {e.ref.hypothesis: e.freshness for e in basis.edges}
+    assert freshness['hiid'] is Freshness.CURRENT
+    assert freshness['h_gone'] is Freshness.BROKEN
+
+
+def test_registry_collection_finds_edges_the_card_does_not_contain(registry):
+    # The motivating case: the relaxation lives in a predictor one repo away.
+    @approximates('Paper.Section.main::hlim', registry=registry)
+    def somewhere_else():
+        return 1
+
+    grounding = grounds('Paper.Section.main', registry=registry)
+    basis = TheoreticalBasis.collect(
+        registry=registry, extra_groundings=[grounding]
+    )
+    assert [e.ref.hypothesis for e in basis.edges] == ['hlim']
+
+
+def test_registry_does_not_sweep_in_ungrounded_edges(registry):
+    assumes('Other.thing::hx', registry=registry)
+    grounding = grounds('Paper.Section.main', registry=registry)
+    basis = TheoreticalBasis.collect(registry=registry, extra_groundings=[grounding])
+    assert basis.edges == ()
+
+
+def test_registry_separates_observed_from_declared(registry):
+    @assumes('A::h1', registry=registry)
+    def ran():
+        return 1
+
+    @assumes('A::h2', registry=registry)
+    def never_ran():
+        return 1
+
+    ran()
+    assert len(registry.observed()) == 1
+    assert len(registry.declared_but_unobserved()) == 1
+
+
+# --------------------------------------------------------------------- hygiene
+
+
+def test_hygiene_library_loads():
+    library = hygiene()
+    assert len(library) >= 5
+    statement = library['Hygiene.Conformal.marginal_coverage_of_exchangeable']
+    assert {h.name for h in statement.hypotheses} == {
+        'hexch',
+        'hsplit',
+        'hscore_fixed',
+        'hquantile',
+    }
+
+
+def test_hygiene_statements_are_honestly_unproved():
+    # They are stated, not formalized. Claiming otherwise would be the exact
+    # dishonesty this package exists to prevent.
+    for statement in hygiene():
+        assert statement.proof is ProofStatus.UNKNOWN
+        assert statement.review is ReviewStatus.DRAFT

--- a/tests/test_theory.py
+++ b/tests/test_theory.py
@@ -17,9 +17,9 @@ from magnet.theory import (
     Relation,
     ReviewStatus,
     Severity,
+    Theorem,
     TheoreticalBasis,
     TheoryRegistry,
-    Theorem,
     approximates,
     assumes,
     checks,
@@ -280,6 +280,42 @@ def test_complete_coverage(formalization, registry):
     assert coverage.is_complete
     assert coverage.max_severity is Severity.NONE
     assert coverage.summary() == 'standing on 4 assumptions: 4 discharged'
+
+
+def test_grounding_contributes_the_formalization_it_names(formalization, registry):
+    # A card that says where its theorem came from should not have to be handed
+    # the same body a second time. When it was, the statement resolved to a
+    # placeholder with no hypotheses, so every assumption came back accounted
+    # for -- the exact failure the unaccounted list exists to catch.
+    basis = TheoreticalBasis.collect(
+        registry=None,
+        extra_groundings=[
+            grounds(
+                'Paper.Section.main',
+                formalization=formalization,
+                registry=registry,
+            )
+        ],
+    )
+    coverage = basis.coverage()
+
+    assert basis.formalizations == (formalization,)
+    assert not coverage.is_complete
+    assert sorted(h.name for h in coverage.unaccounted) == ['hiid', 'hlim', 'hvar', 'psi']
+
+
+def test_explicit_formalization_wins_over_the_grounding_s(formalization, registry):
+    other = Formalization(name='Other', theorems=[Theorem('Paper.Section.main')])
+    basis = TheoreticalBasis.collect(
+        registry=None,
+        extra_groundings=[
+            grounds('Paper.Section.main', formalization=other, registry=registry)
+        ],
+        formalizations=[formalization],
+    )
+
+    assert basis.formalizations == (formalization, other)
+    assert len(basis.coverage().unaccounted) == 4
 
 
 def test_unenumerated_statement_never_reads_as_complete(registry):

--- a/tests/test_theory_shim.py
+++ b/tests/test_theory_shim.py
@@ -1,0 +1,115 @@
+"""
+Tests for the dependency-free shim teams vendor.
+
+Two things have to hold or the shim is worse than useless: annotated code must
+behave identically with the shim or the real package installed, and the shim
+must spell exactly the same API, since a team's annotations are read by the
+real extractor.
+"""
+import textwrap
+
+from magnet.theory import shim
+from magnet.theory.predicates import PREDICATE_NAMES
+from magnet.theory.static import extract_source
+
+
+def test_shim_spells_the_same_predicates():
+    # A predicate that exists in one and not the other is an annotation a team
+    # can write and we cannot read, or vice versa.
+    assert set(shim.PREDICATES) == set(PREDICATE_NAMES)
+    for name in PREDICATE_NAMES:
+        assert callable(getattr(shim, name))
+
+
+def test_shim_imports_nothing_beyond_the_standard_library():
+    # Checked against the parsed imports rather than the text, since the
+    # docstring necessarily shows `from magnet_theory import ...`.
+    import ast
+    import sys
+
+    tree = ast.parse(open(shim.__file__).read())
+    imported = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported |= {alias.name.split('.')[0] for alias in node.names}
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imported.add(node.module.split('.')[0])
+
+    assert imported <= sys.stdlib_module_names, f'non-stdlib imports: {imported}'
+
+
+def test_shim_annotations_are_inert():
+    @shim.approximates('Paper.main::hcover', severity='high')
+    def build(n=64):
+        return n * 2
+
+    assert build(8) == 16
+    assert build.__name__ == 'build'
+
+
+def test_shim_activates_three_ways():
+    edge = shim.assumes('Paper.main::h')
+    assert edge.ref == 'Paper.main::h'
+
+    with shim.substitutes('Paper.main::h') as inner:
+        inner.witness(n=4)
+
+    @shim.satisfies('Paper.main::h')
+    def annotated():
+        return 'ok'
+
+    assert annotated() == 'ok'
+
+
+def test_shim_leaves_classes_alone():
+    @shim.assumes('Paper.main::h')
+    class Predictor:
+        pass
+
+    assert isinstance(Predictor, type)
+    assert Predictor.__name__ == 'Predictor'
+
+
+def test_shim_check_is_truthy_by_its_outcome():
+    assert bool(shim.Check(ok=True))
+    assert not bool(shim.Check(ok=False))
+
+
+def test_shim_context_manager_does_not_swallow():
+    try:
+        with shim.assumes('Paper.main::h'):
+            raise ValueError('boom')
+    except ValueError:
+        pass
+    else:
+        raise AssertionError('the shim swallowed an exception')
+
+
+def test_extractor_reads_shim_annotated_source():
+    # The whole point: a team annotates with the vendored shim, and MAGNET
+    # reads their source without importing either.
+    ledger = extract_source(
+        textwrap.dedent(
+            '''
+            from magnet_theory import approximates, grounds
+
+            @grounds('Paper.claim')
+            def claim(): ...
+
+            @approximates('Paper.main::hcover', severity='high')
+            def build(n=64): ...
+            '''
+        ),
+        filename='team/predictor.py',
+    )
+    assert [(a.predicate, a.ref) for a in ledger] == [
+        ('grounds', 'Paper.claim'),
+        ('approximates', 'Paper.main::hcover'),
+    ]
+
+
+def test_shim_installs_a_copy(tmp_path):
+    destination = shim._install(tmp_path)
+    assert destination.endswith('magnet_theory.py')
+    assert 'def approximates' not in open(destination).read()  # built by a factory
+    assert 'PREDICATES' in open(destination).read()

--- a/tests/test_theory_static.py
+++ b/tests/test_theory_static.py
@@ -1,0 +1,320 @@
+"""
+Tests for static extraction.
+
+The premise of extracting from source is that a repository can be audited
+without installing its dependencies or executing it. So the properties that
+matter are: every syntactic position is found, references that cannot be read
+are *reported* rather than dropped, and nothing here ever imports the parsed
+module.
+"""
+import textwrap
+
+import pytest
+
+from magnet.theory import Formalization, Hypothesis, Theorem
+from magnet.theory.basis import TheoreticalBasis
+from magnet.theory.static import extract_source, extract_tree, lint
+
+
+def parse(source):
+    return extract_source(textwrap.dedent(source), filename='team/predictor.py')
+
+
+def test_finds_every_activation_form():
+    ledger = parse(
+        '''
+        from magnet.theory import approximates, assumes, grounds, substitutes
+
+        assumes('Paper.main::hlip')
+
+        @approximates('Paper.main::hcover')
+        def build(n=64): ...
+
+        def predict():
+            with substitutes('Paper.main::hpsi'):
+                pass
+
+        @grounds('Paper.claim')
+        def claim(): ...
+        '''
+    )
+    found = {(a.predicate, a.form) for a in ledger}
+    assert found == {
+        ('assumes', 'bare'),
+        ('approximates', 'decorator'),
+        ('substitutes', 'with'),
+        ('grounds', 'decorator'),
+    }
+
+
+def test_finds_annotated_parameters():
+    # Several real assumptions are about one knob, not about a function.
+    ledger = parse(
+        '''
+        from typing import Annotated
+        from magnet.theory import approximates
+
+        def __init__(self, num_example_runs: Annotated[int, approximates('Paper.main::hcover')] = 64): ...
+        '''
+    )
+    (found,) = ledger.annotations
+    assert found.form == 'annotation'
+    assert found.target == 'num_example_runs'
+    assert found.ref == 'Paper.main::hcover'
+
+
+def test_records_enclosing_qualname_and_line():
+    ledger = parse(
+        '''
+        from magnet.theory import assumes
+
+        class Predictor:
+            def predict(self):
+                with assumes('Paper.main::hrank'):
+                    pass
+        '''
+    )
+    (found,) = ledger.annotations
+    assert found.qualname == 'Predictor.predict'
+    assert found.line == 6
+    assert found.file == 'team/predictor.py'
+
+
+def test_reads_literal_options():
+    ledger = parse(
+        '''
+        from magnet.theory import substitutes
+
+        substitutes('Paper.main::hpsi', severity='high', kind='different-object',
+                    id='team-psi', informal='an off-the-shelf embedder')
+        '''
+    )
+    (found,) = ledger.annotations
+    assert found.options['severity'] == 'high'
+    assert found.options['kind'] == 'different-object'
+    assert found.options['id'] == 'team-psi'
+
+
+def test_reads_positional_severity():
+    ledger = parse(
+        """
+        from magnet.theory import approximates
+        approximates('Paper.main::hcover', 'high')
+        """
+    )
+    assert ledger.annotations[0].options['severity'] == 'high'
+
+
+def test_unreadable_options_are_named_not_dropped():
+    ledger = parse(
+        '''
+        from magnet.theory import assumes
+        assumes('Paper.main::h', informal=compute_description())
+        '''
+    )
+    (found,) = ledger.annotations
+    assert found.unreadable_options == ('informal',)
+
+
+@pytest.mark.parametrize(
+    'source',
+    [
+        "from magnet.theory import assumes\nassumes('Paper.main::h')",
+        "from magnet.theory import assumes as skips\nskips('Paper.main::h')",
+        "from magnet_theory import assumes\nassumes('Paper.main::h')",
+        "import magnet.theory as th\nth.assumes('Paper.main::h')",
+    ],
+)
+def test_import_spellings(source):
+    ledger = extract_source(source, filename='x.py')
+    assert [a.ref for a in ledger] == ['Paper.main::h']
+
+
+def test_ignores_unrelated_functions_with_the_same_name():
+    # `checks` and `assumes` are ordinary words; matching on the name alone
+    # would produce false positives in unrelated code.
+    ledger = parse(
+        '''
+        from mypackage import assumes
+        assumes('this is not a hypothesis reference')
+        '''
+    )
+    assert len(ledger) == 0
+
+
+def test_resolves_fstring_and_concatenated_references():
+    # Nobody writes a ninety-character declaration name six times.
+    ledger = parse(
+        '''
+        from magnet.theory import assumes
+
+        DECL = 'Paper.Section.main'
+
+        assumes(f'{DECL}::hgap')
+        assumes(DECL + '::hcompetitive')
+        assumes(DECL)
+        '''
+    )
+    assert [a.ref for a in ledger] == [
+        'Paper.Section.main::hgap',
+        'Paper.Section.main::hcompetitive',
+        'Paper.Section.main',
+    ]
+
+
+def test_resolves_object_style_references():
+    # Code written against the object API is not left out.
+    ledger = parse(
+        '''
+        from magnet.theory import assumes
+
+        QE = FORMALIZATION['Paper.Section.main']
+
+        assumes(QE['hgap'])
+        '''
+    )
+    assert [a.ref for a in ledger] == ['Paper.Section.main::hgap']
+
+
+def test_unresolvable_reference_is_reported_not_dropped():
+    ledger = parse(
+        '''
+        from magnet.theory import assumes
+        assumes(pick_hypothesis_at_random())
+        '''
+    )
+    (found,) = ledger.annotations
+    assert not found.resolved
+    assert found.ref_expr == 'pick_hypothesis_at_random()'
+
+    (issue,) = lint(ledger)
+    assert issue.kind == 'unresolved-reference'
+
+
+def test_syntax_errors_are_recorded():
+    ledger = extract_source('def broken(:\n', filename='bad.py')
+    assert ledger.errors
+    assert lint(ledger)[0].kind == 'unparseable'
+
+
+def test_extract_tree_skips_noise_directories(tmp_path):
+    (tmp_path / 'pkg').mkdir()
+    (tmp_path / 'pkg' / 'a.py').write_text(
+        "from magnet.theory import assumes\nassumes('Paper.main::h')\n"
+    )
+    (tmp_path / '.venv').mkdir()
+    (tmp_path / '.venv' / 'b.py').write_text(
+        "from magnet.theory import assumes\nassumes('Vendored.thing::h')\n"
+    )
+    ledger = extract_tree(tmp_path)
+    assert [a.ref for a in ledger] == ['Paper.main::h']
+
+
+# ----------------------------------------------------------------------- lint
+
+
+@pytest.fixture
+def formalization():
+    return Formalization(
+        name='Example',
+        theorems=[
+            Theorem(
+                declaration='Paper.main',
+                hypotheses=[Hypothesis('hcover'), Hypothesis('hgap')],
+            )
+        ],
+    )
+
+
+def test_lint_catches_a_renamed_binder(formalization):
+    # The check the object form used to do at import, now done without one.
+    ledger = parse(
+        '''
+        from magnet.theory import assumes
+        assumes('Paper.main::h_renamed_upstream')
+        '''
+    )
+    (issue,) = lint(ledger, [formalization])
+    assert issue.kind == 'unknown-binder'
+    assert 'hcover, hgap' in issue.message
+
+
+def test_lint_catches_an_unknown_declaration(formalization):
+    ledger = parse(
+        '''
+        from magnet.theory import assumes
+        assumes('Paper.renamed::hcover')
+        '''
+    )
+    (issue,) = lint(ledger, [formalization])
+    assert issue.kind == 'unknown-declaration'
+
+
+def test_lint_catches_an_edge_with_no_binder(formalization):
+    ledger = parse(
+        '''
+        from magnet.theory import assumes
+        assumes('Paper.main')
+        '''
+    )
+    kinds = {i.kind for i in lint(ledger, [formalization])}
+    assert 'missing-binder' in kinds
+
+
+def test_lint_allows_a_grounding_without_a_binder(formalization):
+    ledger = parse(
+        '''
+        from magnet.theory import grounds
+        grounds('Paper.main')
+        '''
+    )
+    assert lint(ledger, [formalization]) == []
+
+
+def test_lint_catches_duplicate_ids(formalization):
+    ledger = parse(
+        '''
+        from magnet.theory import assumes
+        assumes('Paper.main::hcover', id='dup')
+        assumes('Paper.main::hgap', id='dup')
+        '''
+    )
+    (issue,) = lint(ledger, [formalization])
+    assert issue.kind == 'duplicate-id'
+
+
+def test_clean_ledger_lints_clean(formalization):
+    ledger = parse(
+        '''
+        from magnet.theory import assumes, grounds
+        grounds('Paper.main')
+        assumes('Paper.main::hcover', id='a')
+        assumes('Paper.main::hgap', id='b')
+        '''
+    )
+    assert lint(ledger, [formalization]) == []
+
+
+# -------------------------------------------------------- static -> reporting
+
+
+def test_static_ledger_produces_the_same_report_shape(formalization):
+    ledger = parse(
+        '''
+        from magnet.theory import approximates, assumes, grounds
+
+        grounds('Paper.main')
+
+        @approximates('Paper.main::hcover', severity='high', informal='fixed pool')
+        def build(n=64): ...
+        '''
+    )
+    basis = TheoreticalBasis.from_ledger(ledger, [formalization])
+    coverage = basis.coverage()
+
+    assert [h.name for h in coverage.unaccounted] == ['hgap']
+    (edge,) = coverage.per_theorem[0].gaps
+    assert edge.informal == 'fixed pool'
+    assert str(edge.severity) == 'high'
+    # Nothing ran, so there is no evidence -- only the ledger.
+    assert edge.observations == []


### PR DESCRIPTION
An initial vibe at the idea to markup sections of the source with theory annotations to serve as an explicit connection point.

The idea _should_ be that a TA1 team recognizes a part of there code is directly relevant to a theoretical claim, either it is a place where a theoretical idea is relaxed or is invoked as a motivation, is used directly, etc... There is some predicate relationship between the annotated practice and the theory.

That annotation should be in the form of a decorator or a context manager. The decorator gives an easy way to annotate functions, and the context manager gives an easy way to do more fine-grained inline markings of the code. At runtime they should be no-ops.

To consume them, we don't import the code, instead we use static analysis to identify where they are in the code that executes the practices of the theory and that gives us the metadata that can be directly hooked up to a dashboard. By doing a similar process with the lean4 code, we can make a real codified connection that goes well beyond handwaving. We produce a grounded claim that can be audited, and in some cases formally verified. 

Now, I have not reviewed this code yet. I've done some back and forth with Claude on the idea, and what I want it to look like, but this is still a WIP. 