### PR TITLE
Fix usage of shadowed validate. 

### DIFF
--- a/magnet/evaluation.py
+++ b/magnet/evaluation.py
@@ -1105,7 +1105,13 @@ def main(argv: Optional[List[str]] = None, **kwargs: Any) -> None:
         special_options=False,
     )
 
-    if args.validate == 'only':
+    # Item access, not `args.validate`: the option shares its name with
+    # `kwconf.Config.validate`, and the method wins attribute lookup. Reading it
+    # as an attribute yields a bound method, which silently compares unequal to
+    # every mode and turns validation off. See tests/test_kwconf_configs.py.
+    validate = args['validate']
+
+    if validate == 'only':
         try:
             with open(args.path, 'r') as f:
                 cfg = yaml.safe_load(f)
@@ -1117,8 +1123,7 @@ def main(argv: Optional[List[str]] = None, **kwargs: Any) -> None:
             sys.exit(1)
         return
 
-
-    card = EvaluationCard(args.path, args.output_path, validate=args.validate)
+    card = EvaluationCard(args.path, args.output_path, validate=validate)
     if args.override is not None:
         card.replace(args.override)
 

--- a/tests/test_kwconf_configs.py
+++ b/tests/test_kwconf_configs.py
@@ -1,23 +1,47 @@
+import importlib
+import inspect
+import pkgutil
+
 import kwconf
 
+import magnet
 from magnet.backends.helm.cli.download_helm_results import DownloadHelmConfig
 from magnet.backends.helm.cli.inspect_helm_models import InspectHelmModelsConfig
-from magnet.backends.helm.cli.materialize_helm_run import MaterializeHelmRunConfig
-from magnet.backends.helm.cli.materialize_helm_run_from_spec import (
-    MaterializeHelmRunFromSpecConfig,
-)
 from magnet.evaluation import EvaluationConfig
 
 
+def _discover_config_classes():
+    """
+    Every :class:`kwconf.Config` magnet defines.
+
+    Discovered rather than listed, because a config added later is exactly the
+    one nobody remembers to add to a list -- and the checks below are only worth
+    anything if they cover configs written after them. Configs merely imported
+    from a dependency are skipped; we do not control their option names.
+    """
+    found = {}
+    for module_info in pkgutil.walk_packages(magnet.__path__, 'magnet.'):
+        module = importlib.import_module(module_info.name)
+        for obj in vars(module).values():
+            if not inspect.isclass(obj) or not issubclass(obj, kwconf.Config):
+                continue
+            if obj is kwconf.Config or not obj.__module__.startswith('magnet.'):
+                continue
+            found[f'{obj.__module__}.{obj.__name__}'] = obj
+    return [found[key] for key in sorted(found)]
+
+
+ALL_CONFIG_CLASSES = _discover_config_classes()
+
+
+def test_configs_were_discovered():
+    # A discovery bug would make the checks below vacuously pass.
+    assert EvaluationConfig in ALL_CONFIG_CLASSES
+    assert len(ALL_CONFIG_CLASSES) >= 5
+
+
 def test_kwconf_schemas_are_valid():
-    config_classes = [
-        DownloadHelmConfig,
-        InspectHelmModelsConfig,
-        MaterializeHelmRunConfig,
-        MaterializeHelmRunFromSpecConfig,
-        EvaluationConfig,
-    ]
-    for config_cls in config_classes:
+    for config_cls in ALL_CONFIG_CLASSES:
         assert issubclass(config_cls, kwconf.Config)
         config_cls.validate()
 
@@ -36,9 +60,56 @@ def test_validate_alias():
     evaluation_cfg = EvaluationConfig.cli(
         argv=['card.yaml', '--validate', 'warning']
     )
-    assert evaluation_cfg.validate == 'warning'
+    assert evaluation_cfg['validate'] == 'warning'
 
     evaluation_cfg = EvaluationConfig.cli(
         argv=False, data={'path': 'card.yaml', 'validate': 'off'}
     )
-    assert evaluation_cfg.validate == 'off'
+    assert evaluation_cfg['validate'] == 'off'
+
+
+def test_validate_option_is_only_readable_as_an_item():
+    """
+    The ``validate`` option cannot be read as an attribute, and never will be.
+
+    ``kwconf.Config.validate()`` is a method, and a method wins attribute
+    lookup over a config value. This is asserted rather than merely avoided
+    because the failure is silent: ``args.validate`` yields a bound method,
+    which compares unequal to every mode, so the card is parsed with schema
+    validation off no matter what was asked for.
+    """
+    cfg = EvaluationConfig.cli(argv=['card.yaml', '--validate', 'error'])
+
+    assert cfg['validate'] == 'error'
+    assert callable(cfg.validate)
+    assert cfg.validate != 'error'
+
+
+def test_no_config_option_shadows_a_config_method():
+    """
+    No option in any config may collide with a ``kwconf.Config`` attribute.
+
+    ``validate`` is the one that got through, and the names still available to
+    collide -- ``get``, ``keys``, ``update``, ``load``, ``dump``, ``copy`` --
+    are ordinary enough that the next one is a matter of time. A new option
+    named for one of them should fail here rather than in a run that quietly
+    skipped a step.
+    """
+    reserved = {name for name in dir(kwconf.Config) if not name.startswith('_')}
+
+    known = {
+        # Renaming it would break `--validate` and every card that sets it, so
+        # it is read as an item instead. See magnet/evaluation.py:main.
+        (EvaluationConfig, 'validate'),
+    }
+
+    collisions = set()
+    for config_cls in ALL_CONFIG_CLASSES:
+        for key in config_cls().keys():
+            if key in reserved and (config_cls, key) not in known:
+                collisions.add(f'{config_cls.__name__}.{key}')
+
+    assert not collisions, (
+        f'config options shadow kwconf.Config attributes: {sorted(collisions)}. '
+        'Rename the option, or read it with item access and add it to `known`.'
+    )

--- a/tests/test_kwconf_configs.py
+++ b/tests/test_kwconf_configs.py
@@ -68,21 +68,18 @@ def test_validate_alias():
     assert evaluation_cfg['validate'] == 'off'
 
 
-def test_validate_option_is_only_readable_as_an_item():
+def test_validate_behavior_has_not_changed():
     """
-    The ``validate`` option cannot be read as an attribute, and never will be.
-
-    ``kwconf.Config.validate()`` is a method, and a method wins attribute
-    lookup over a config value. This is asserted rather than merely avoided
-    because the failure is silent: ``args.validate`` yields a bound method,
-    which compares unequal to every mode, so the card is parsed with schema
-    validation off no matter what was asked for.
+    Kwconf.Config defines a ``.validate`` method, and we have a validate
+    CLI key, which shadows it. For some reason claude thought that the method
+    would win, but it seems the user value wins. This test just asserts
+    that behavior so we get a red dashboard if it ever changes.
     """
     cfg = EvaluationConfig.cli(argv=['card.yaml', '--validate', 'error'])
 
     assert cfg['validate'] == 'error'
-    assert callable(cfg.validate)
-    assert cfg.validate != 'error'
+    assert not callable(cfg.validate), ('The user item shadows the .validate method')
+    assert cfg.validate == 'error'
 
 
 def test_no_config_option_shadows_a_config_method():


### PR DESCRIPTION
EDIT: I have the mechanism backwards. I have not rewritten the issue text.

Long story short: 

We were using `config.validate`, but with a `config: kwconf.Config` instance that resolves to the `kwconf.Config.validate` method, not the value of the CLI flag. Using `config['validate']` unambiguously will always resolve to the CLI flag value. That is the fix. (Using `config.namespace.validate` would also work)

---

Long story long:

In kwconf the canonical way to access a variable is via dictionary lookup, not using the namespace. This is only important for attributes that are shadowed by kwconf.Config convenience methods. I.e. get, pop, update, cli, and in this case: validate.

I'm on the fence about if I want to make some exception for this method. I've sort of dug myself into a backwards compatability nightmare again, and because kwconf is so new, I'm more willing to break backwards compatability in the initial versions, but doing this has negative tradeoffs that go against the design I wanted for kwconf. Namely: you can treat the config object as a dictionary, which means there _must_ be conflict between some names being used as attributes and their convenience methods. I.e. to behave like a dictionary the user can never  specify a `--get` cli flag, otherwise we don't have the `.get` method anymore. So the same argument I used to justify `.get` also applies to `.validate`, but the second one is trickier, because it is more likely to be used as a CLI argument (as demonstrated here).

The latest kwconf 0.11.0 does take some preventative measures by defining private `_` prefixed versions of every method it needs, and in its internal usage it only uses those, so if I ever decided that a Config should behave like a true namespace, then that won't be a big refactor. I likely will never have this. There is also always the `.namespace` (or now also `._namespace`) way to access a true namespace object. So the user has ways to make easy patches to get full namespace behavior.

The full list of these foot-gun methods is:

```python
['argparse',
 'asdict',
 'clear',
 'cli',
 'cls_from_argparse',
 'coerce',
 'copy',
 'demo',
 'dump',
 'dumps',
 'from_cli',
 'from_env',
 'from_yaml',
 'get',
 'items',
 'keys',
 'load',
 'namespace',
 'parse_args',
 'parse_known_args',
 'pop',
 'popitem',
 'port_from_argparse',
 'port_from_click',
 'port_to_argparse',
 'port_to_config',
 'to_dict',
 'update',
 'update_defaults',
 'validate',
 'values']
```

Claude added a good test to see if any of these are ever newly introduced here as well.

I've talked with LLMs about this issue at length, so if anyone has any non-LLM insight or opinions here, I'm interested in hearing them.

And to put things in perspective, this is still a very minor issue that users are not too likely to run into, and scriptconfig has the same problem (except it doesn't have a validate method so not exactly the same problem), but I still think there might be a better way to design it. 

---

EDIT: Hmm, I may have gotten this backwards. It seems that using `.validate` will give you the user defined variable if you overwrite it. (This is my first time writing a non-trivial amount of code in awhile)


```python

"""
In kwconf version 0.11.0 (and previous versions) we have a footgun
"""

import kwconf


class Config1(kwconf.Config):
    """
    A config that DOES NOT define a "validate" key.
    """

    validation = kwconf.Value(False, help='No special values here')


class Config2(kwconf.Config):
    """
    A config that DOES define a "validate" key.
    """

    validate = kwconf.Value(False, help=(
        'The specific CLI value called "validate" '
        'has a non-intuitive behavior'))


# Codify a way to express every important case:
# Instntiate via: .cli or via .__init__


class_case_infos = [
    {'cls_case_name': 'ConfigWithoutValidate', 'cls': Config1, 'key': 'validation'},
    {'cls_case_name': 'ConfigWithValidate', 'cls': Config2, 'key': 'validate'},
]


results = []

for class_case in class_case_infos:

    cls = class_case['cls']
    key = class_case['key']
    cls_case_name = class_case['cls_case_name']

    cli_kwarg_cases = [
        {'instantiation': 'cli-empty', 'kwargs': {}},
        {'instantiation': 'cli-argv', 'kwargs': {'argv': f'--{key}=some-value'}},
    ]

    # Common instantiation via .cli classmethod
    for cli_kwarg_case in cli_kwarg_cases:
        cli_kwargs = cli_kwarg_case['kwargs']
        config = cls.cli(**cli_kwargs)
        row = {
            'cls_case_name': cls_case_name,
            'instantiation': cli_kwarg_case['instantiation'],
            'config': config,
        }
        results.append(row)

    # Direct instantiation via .__init__ constructor
    init_kwarg_cases = [
        {'instantiation': '__init__-empty', 'kwargs': {}},
        {'instantiation': '__init__-key', 'kwargs': {key: 'some-value'}},
    ]

    for kwarg_case in init_kwarg_cases:
        cli_kwargs = kwarg_case['kwargs']
        config = cls(**cli_kwargs)
        row = {
            'cls_case_name': cls_case_name,
            'instantiation': kwarg_case['instantiation'],
            'config': config,
        }
        results.append(row)


for result in results:
    config = result['config']
    result['config.asdict()'] = config.asdict()
    result['config.validate='] = config.validate
    try:
        result['config["validate"]'] = config['validate']
    except KeyError as ex:
        result['config["validate"]'] = ex


print(f'results = {ub.urepr(results, nl=1)}')


# Print results table:
import pandas as pd
df = pd.DataFrame(results)
print(df)
```

Shows that `.validate` will not return the method if the user overwrites it, which is probably the more intuitive behavior. After all, the user knows that they specified a `validate` key, they might not know there is a `validate` method in the parent class, so they should get whatever is closer to the leaf of the inheritance tree.

```
           cls_case_name   instantiation        config               config.asdict()                                   config.validate= config["validate"]
0  ConfigWithoutValidate       cli-empty  [validation]         {'validation': False}  <bound method Config.validate of <class '__mai...         'validate'
1  ConfigWithoutValidate        cli-argv  [validation]  {'validation': 'some-value'}  <bound method Config.validate of <class '__mai...         'validate'
2  ConfigWithoutValidate  __init__-empty  [validation]         {'validation': False}  <bound method Config.validate of <class '__mai...         'validate'
3  ConfigWithoutValidate    __init__-key  [validation]  {'validation': 'some-value'}  <bound method Config.validate of <class '__mai...         'validate'
4     ConfigWithValidate       cli-empty    [validate]           {'validate': False}                                              False              False
5     ConfigWithValidate        cli-argv    [validate]    {'validate': 'some-value'}                                         some-value         some-value
6     ConfigWithValidate  __init__-empty    [validate]           {'validate': False}                                              False              False
7     ConfigWithValidate    __init__-key    [validate]    {'validate': 'some-value'}                                         some-value         some-value
```

That makes me feel a little better about it. Still a footgun, but not as bad as I thought. 