### PR TITLE
Evaluation Recipes 

### DIFF
--- a/magnet/card.py
+++ b/magnet/card.py
@@ -1,0 +1,237 @@
+"""
+The evaluation result card: what a recipe produces.
+
+MAGNET has used "evaluation card" for two different things — the YAML program
+that specifies an evaluation, and the result of running it. This module names
+the second one :class:`EvaluationResultCard`; the first is an
+:class:`~magnet.recipe.EvaluationRecipe`.
+
+Neither name is taken. :class:`magnet.evaluation.EvaluationCard` remains what
+it has always been — the loaded YAML program and the runner that executes it —
+and nothing here changes, wraps, or deprecates it. A team that never writes a
+recipe never meets these classes.
+
+The split is the point. Today one object is the program, the run, and the
+result at once, so "the card said VERIFIED" and "the card sweeps three
+thresholds" are sentences about the same thing. Separating them means a result
+can be written, diffed, and archived without dragging the runner along, and it
+gives the result somewhere to record what it was standing on.
+
+A result card has two components:
+
+    empirical    — the verdict, its per-sweep outcomes, metrics, provenance
+    theoretical  — reserved; see :attr:`EvaluationResultCard.theoretical`
+
+Either may be absent. A card with only an empirical component is every card
+MAGNET produces today, and is everything this module builds. The second slot is
+a placeholder here on purpose: it is filled by separate work, and the shape of
+the recipe-to-result-card pipeline can be judged without it.
+
+Example:
+    >>> from magnet.card import EvaluationResultCard, EmpiricalResult, Verdict
+    >>> card = EvaluationResultCard(
+    ...     title='Addition commutes',
+    ...     empirical=EmpiricalResult(verdict=Verdict.VERIFIED),
+    ... )
+    >>> print(card.render())
+    Addition commutes
+    ================================
+    RESULT:  VERIFIED
+    BASIS:   not recorded
+"""
+import platform
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from enum import StrEnum
+from typing import Any
+
+__all__ = [
+    'Verdict',
+    'ClaimOutcome',
+    'EmpiricalResult',
+    'EvaluationResultCard',
+]
+
+
+class Verdict(StrEnum):
+    """
+    The outcome of evaluating a claim.
+
+    These are the strings MAGNET has always used, kept verbatim so that verdicts
+    from a recipe and from the YAML runner are comparable without translation.
+    """
+
+    VERIFIED = 'VERIFIED'
+    FALSIFIED = 'FALSIFIED'
+    INCONCLUSIVE = 'INCONCLUSIVE'
+    UNEVALUATED = 'UNEVALUATED'
+
+
+@dataclass
+class ClaimOutcome:
+    """One claim evaluated at one point of the sweep."""
+
+    claim: str
+    verdict: Verdict = Verdict.UNEVALUATED
+    message: str = ''
+    symbols: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict:
+        return {
+            'claim': self.claim,
+            'verdict': str(self.verdict),
+            'message': self.message,
+            'symbols': _simple_view(self.symbols),
+        }
+
+
+@dataclass
+class EmpiricalResult:
+    """The measured half of a card."""
+
+    verdict: Verdict = Verdict.UNEVALUATED
+    outcomes: tuple[ClaimOutcome, ...] = ()
+    aggregation: dict[str, Any] = field(default_factory=dict)
+    metrics: dict[str, Any] = field(default_factory=dict)
+    provenance: dict[str, Any] = field(default_factory=dict)
+
+    @staticmethod
+    def default_provenance() -> dict[str, Any]:
+        from magnet import __version__
+
+        return {
+            'timestamp': datetime.now(timezone.utc).isoformat(),
+            'host': platform.node(),
+            'python': platform.python_version(),
+            'magnet': __version__,
+        }
+
+    @property
+    def counts(self) -> dict[str, int]:
+        counts = {str(v): 0 for v in Verdict}
+        for outcome in self.outcomes:
+            counts[str(outcome.verdict)] += 1
+        return {k: v for k, v in counts.items() if v}
+
+    def to_dict(self) -> dict:
+        return {
+            'verdict': str(self.verdict),
+            'counts': self.counts,
+            'aggregation': self.aggregation,
+            'metrics': self.metrics,
+            'provenance': self.provenance,
+            'outcomes': [o.to_dict() for o in self.outcomes],
+        }
+
+
+@dataclass
+class EvaluationResultCard:
+    """
+    A produced evaluation artifact: what was claimed, what was measured, and
+    what the measurement is standing on.
+    """
+
+    title: str = ''
+    description: str = ''
+    version: str = ''
+    organizations: tuple[str, ...] = ()
+    tags: tuple[str, ...] = ()
+    recipe: str | None = None
+    empirical: EmpiricalResult | None = None
+
+    #: Reserved for what the verdict is standing on: the statements the claim is
+    #: grounded on and every way the experiment departs from their hypotheses.
+    #: Separate work fills this in; nothing in this module interprets it, which
+    #: is why it is typed loosely and only asked for a ``to_dict``. Keeping the
+    #: slot visible is deliberate — a result card that cannot say what it
+    #: assumed is the gap this structure exists to close, and leaving the field
+    #: out would hide that it is still open.
+    theoretical: Any = None
+
+    @property
+    def verdict(self) -> Verdict:
+        return self.empirical.verdict if self.empirical else Verdict.UNEVALUATED
+
+    def to_dict(self) -> dict:
+        return {
+            'title': self.title,
+            'description': self.description,
+            'version': self.version,
+            'organizations': list(self.organizations),
+            'tags': list(self.tags),
+            'recipe': self.recipe,
+            'empirical': self.empirical.to_dict() if self.empirical else None,
+            # Whatever occupies the slot is asked for its own dict rather than
+            # inspected here, so filling it in does not touch this method.
+            'theoretical': self.theoretical.to_dict() if self.theoretical else None,
+        }
+
+    def write(self, path) -> None:
+        """Write the card as JSON."""
+        import json
+
+        import ubelt as ub
+
+        path = ub.Path(path)
+        path.parent.ensuredir()
+        path.write_text(json.dumps(self.to_dict(), indent=2, ensure_ascii=False, default=str) + '\n')
+
+    def render(self, verbose: bool = False) -> str:
+        """
+        Human-readable summary.
+
+        The basis line sits directly under the verdict on purpose. A verdict
+        read without knowing what it assumes is the thing this whole mechanism
+        exists to prevent.
+        """
+        lines = [self.title, '================================']
+        lines.append(f'RESULT:  {self.verdict}')
+
+        if self.empirical and len(self.empirical.outcomes) > 1:
+            counts = ', '.join(f'{v} {k}' for k, v in self.empirical.counts.items())
+            lines.append(f'         ({counts})')
+
+        lines.extend(self._basis_lines(verbose=verbose))
+        return '\n'.join(lines)
+
+    def _basis_lines(self, verbose: bool = False) -> list[str]:
+        """
+        What the verdict is standing on.
+
+        The seam for :attr:`theoretical`. Today a result card knows nothing
+        about its own basis and says so; the work that fills the slot in
+        replaces this method and nothing else in the module.
+        """
+        if self.theoretical is None:
+            return ['BASIS:   not recorded']
+        return [f'BASIS:   {self.theoretical}']
+
+    def summarize(self, verbose: bool = False) -> None:
+        print(self.render(verbose=verbose))
+
+
+def _simple_view(symbols: dict[str, Any]) -> dict[str, Any]:
+    """
+    Keep only symbol values that serialize cleanly.
+
+    Symbol values are arbitrary — dataframes, fitted models, HELM suite handles.
+    A card has to be writable to JSON, so anything that is not obviously
+    representable is summarized by its type rather than dropped silently.
+    """
+    out = {}
+    for key, value in symbols.items():
+        if key.startswith('__'):
+            continue
+        if isinstance(value, (int, float, str, bool, type(None))):
+            out[key] = value
+        elif isinstance(value, (list, tuple, dict)):
+            try:
+                import json
+
+                json.dumps(value)
+                out[key] = value
+            except (TypeError, ValueError):
+                out[key] = f'<{type(value).__name__}>'
+        else:
+            out[key] = f'<{type(value).__name__}>'
+    return out

--- a/magnet/examples/commutative_arithmetic.py
+++ b/magnet/examples/commutative_arithmetic.py
@@ -1,0 +1,99 @@
+"""
+The same evaluation as ``magnet/cards/simple.yaml``, written as a recipe.
+
+This module exists to be read side by side with that card. It is a deliberate
+line-for-line port and not a showcase: same title, same symbols, same claim,
+same verdict. What differs is only how the program is expressed, which is the
+thing under review.
+
+The YAML says::
+
+    symbols:
+      int_range_even:
+        metadata:
+          display_name: "Set of Even Numbers"
+        type: List[int]
+        python: |
+          def create_even_range(start=-10, end=10):
+            return [n for n in range(start, end+1) if n % 2 == 0]
+          int_range_even = create_even_range()
+
+      int_range_odd:
+        type: List[int]
+        depends_on:
+          - int_range_even
+        python: |
+          int_range_odd = [n + 1 for n in int_range_even]
+
+Three things are worth noticing in the Python below. The body is code rather
+than a string, so a typo in it is a syntax error at import instead of a
+traceback out of ``exec`` at run time. ``int_range_odd`` declares its dependency
+by taking ``int_range_even`` as a parameter, so the graph cannot disagree with
+the code the way a hand-maintained ``depends_on`` list can. And the YAML block
+has to end by binding its own name -- ``int_range_even = create_even_range()``
+-- where the function just returns.
+
+What comes back is the other half of the change: :meth:`evaluate` returns an
+:class:`~magnet.card.EvaluationResultCard`, a result rather than the program
+that produced it, whereas :class:`magnet.evaluation.EvaluationCard` is loaded
+from the YAML and is both at once.
+
+Run it::
+
+    python -m magnet.examples.commutative_arithmetic
+"""
+from magnet.recipe import claim, recipe, symbol
+
+
+def create_even_range(start: int = -10, end: int = 10) -> list[int]:
+    """
+    The helper the YAML card defines inside its ``python:`` block.
+
+    Out here it is an ordinary function: importable, type-annotated, and
+    reachable by a test. Inside the block it was three lines of string that no
+    tool could see.
+
+    Example:
+        >>> create_even_range(0, 5)
+        [0, 2, 4]
+    """
+    return [n for n in range(start, end + 1) if n % 2 == 0]
+
+
+@recipe(
+    title='Arithmetic - Addition Commutative Property',
+    description='Addition is commutative on pairs of even and odd integers',
+    category='Mathematical Properties',
+    version='1.0',
+    organizations=['Kitware'],
+    submitter={'name': 'Kitware TA2 Team', 'email': 'aiq-ta2@kitware.com'},
+    tags=['example'],
+    links=[
+        {
+            'title': 'MAGNET',
+            'url': 'https://github.com/AIQ-Kitware/aiq-magnet',
+            'type': 'software',
+        }
+    ],
+)
+class CommutativeAddition:
+    @symbol(type='List[int]', display_name='Set of Even Numbers')
+    def int_range_even():
+        return create_even_range()
+
+    @symbol(type='List[int]', display_name='Set of Odd Numbers')
+    def int_range_odd(int_range_even):
+        return [n + 1 for n in int_range_even]
+
+    @claim
+    def commutes(int_range_even, int_range_odd):
+        for even, odd in zip(int_range_even, int_range_odd):
+            assert even + odd == odd + even, f'{even} + {odd} is not commutative'
+
+
+def main() -> None:
+    CommutativeAddition.evaluate().summarize()
+
+
+if __name__ == '__main__':
+    main()

--- a/magnet/recipe.py
+++ b/magnet/recipe.py
@@ -1,0 +1,655 @@
+"""
+Evaluation recipes: cards defined in Python instead of YAML.
+
+A recipe is the *program* half of an evaluation — symbols, sweeps, and a claim.
+Running it produces an :class:`~magnet.card.EvaluationResultCard`.
+
+MAGNET's YAML cards express the same program as a dependency graph of Python
+snippets held in strings. That is fine for ``threshold: 0.1`` and poor for
+anything substantial: a string gets no linting, no import resolution, no type
+checking, no test coverage, and a traceback that points into ``exec``. Writing
+the same graph as decorated functions gets all of it back, and dependencies come
+from the function signature rather than a hand-maintained ``depends_on`` list
+that can silently disagree with the code beneath it.
+
+Writing the claim as a function also gives later work something to decorate --
+an annotation recording what the experiment assumed can attach to the code that
+assumes it. :meth:`EvaluationRecipe.basis` is the seam where that arrives; it
+returns ``None`` here, and this module needs nothing else to be judged.
+
+Nothing here is on the path of an existing evaluation. A recipe compiles back to
+the YAML card schema (:meth:`EvaluationRecipe.to_schema_dict`), so the runner is
+not forked; :class:`magnet.evaluation.EvaluationCard` is untouched, and teams
+who write YAML keep writing YAML.
+
+Example:
+    >>> from magnet.recipe import recipe, symbol, claim, Sweep
+    >>>
+    >>> @recipe(title='Addition commutes', version='1.0')
+    ... class Commutativity:
+    ...     offset = Sweep([1, 2, 3])
+    ...
+    ...     @symbol
+    ...     def evens():
+    ...         return [n for n in range(-10, 11) if n % 2 == 0]
+    ...
+    ...     @claim
+    ...     def commutes(evens, offset):
+    ...         for even in evens:
+    ...             assert even + offset == offset + even
+    >>>
+    >>> card = Commutativity.evaluate()
+    >>> card.verdict
+    <Verdict.VERIFIED: 'VERIFIED'>
+    >>> sorted(card.empirical.counts.items())
+    [('VERIFIED', 3)]
+"""
+import inspect
+from dataclasses import dataclass, field
+from graphlib import TopologicalSorter
+from itertools import product
+from typing import Any, Callable, Iterable, Sequence
+
+from magnet.card import ClaimOutcome, EmpiricalResult, EvaluationResultCard, Verdict
+
+__all__ = [
+    'recipe',
+    'symbol',
+    'claim',
+    'Sweep',
+    'Symbol',
+    'Claim',
+    'EvaluationRecipe',
+]
+
+DEFAULT_CLAIM_AGGREGATION_STRATEGY = {'type': 'all'}
+
+
+@dataclass(frozen=True)
+class Sweep:
+    """
+    A symbol that takes each of several values in turn.
+
+    The claim is evaluated once per point of the cartesian product of every
+    sweep in the recipe, exactly as the YAML runner does.
+    """
+
+    values: tuple
+    type: str | None = None
+
+    def __init__(self, values: Iterable, type: str | None = None) -> None:
+        object.__setattr__(self, 'values', tuple(values))
+        object.__setattr__(self, 'type', type)
+
+
+@dataclass
+class Symbol:
+    """One node of a recipe's dependency graph."""
+
+    name: str
+    func: Callable | None = None
+    value: Any = None
+    sweep: tuple | None = None
+    type: str | None = None
+    display_name: str | None = None
+    display: bool | None = None
+    metric: dict | None = None
+    dependencies: tuple[str, ...] = ()
+
+    @property
+    def is_computed(self) -> bool:
+        return self.func is not None
+
+    def compute(self, **kwargs) -> Any:
+        if self.func is None:
+            return self.value
+        return self.func(**kwargs)
+
+
+@dataclass
+class Claim:
+    """An assertion over resolved symbols."""
+
+    name: str
+    func: Callable
+    dependencies: tuple[str, ...] = ()
+
+    def evaluate(self, context: dict) -> ClaimOutcome:
+        """
+        Run the claim and translate exceptions into a verdict.
+
+        The mapping matches the YAML runner's: an ``AssertionError`` is a
+        falsification (the claim was tested and is false), anything else is
+        inconclusive (the claim was never actually tested).
+        """
+        kwargs = {dep: context[dep] for dep in self.dependencies if dep in context}
+        missing = [dep for dep in self.dependencies if dep not in context]
+        if missing:
+            return ClaimOutcome(
+                claim=self.name,
+                verdict=Verdict.INCONCLUSIVE,
+                message=f'SymbolNotResolved: {", ".join(missing)}',
+                symbols=dict(context),
+            )
+        try:
+            self.func(**kwargs)
+        except AssertionError as ex:
+            return ClaimOutcome(
+                claim=self.name,
+                verdict=Verdict.FALSIFIED,
+                message=f'Assertion does not hold: {ex}',
+                symbols=dict(context),
+            )
+        except Exception as ex:
+            return ClaimOutcome(
+                claim=self.name,
+                verdict=Verdict.INCONCLUSIVE,
+                message=f'ERROR evaluating claim: {ex!r}',
+                symbols=dict(context),
+            )
+        return ClaimOutcome(claim=self.name, verdict=Verdict.VERIFIED, symbols=dict(context))
+
+
+def symbol(
+    func: Callable | None = None,
+    type: str | None = None,
+    display_name: str | None = None,
+    display: bool | None = None,
+    metric: dict | None = None,
+):
+    """
+    Mark a function as a symbol of the recipe.
+
+    Its parameter names are its dependencies — there is no separate
+    ``depends_on`` list to fall out of sync with the body. Usable bare
+    (``@symbol``) or called (``@symbol(type='float')``).
+
+    Example:
+        >>> @symbol(type='float')
+        ... def ratio(numerator, denominator):
+        ...     return numerator / denominator
+        >>> ratio.__magnet_symbol__['type']
+        'float'
+    """
+
+    def _decorate(fn):
+        fn.__magnet_symbol__ = {
+            'type': type,
+            'display_name': display_name,
+            'display': display,
+            'metric': metric,
+        }
+        return fn
+
+    if func is not None:
+        return _decorate(func)
+    return _decorate
+
+
+def claim(func: Callable | None = None, name: str | None = None):
+    """
+    Mark a function as a claim: it asserts, and raises if the claim is false.
+
+    Its parameter names are the symbols it needs.
+
+    Example:
+        >>> @claim
+        ... def bounded(score, threshold):
+        ...     assert score < threshold, f'{score} exceeds {threshold}'
+        >>> bounded.__magnet_claim__['name'] is None
+        True
+    """
+
+    def _decorate(fn):
+        fn.__magnet_claim__ = {'name': name}
+        return fn
+
+    if func is not None:
+        return _decorate(func)
+    return _decorate
+
+
+@dataclass
+class EvaluationRecipe:
+    """
+    A runnable evaluation program.
+
+    Built by the :func:`recipe` decorator rather than constructed directly.
+    """
+
+    title: str = ''
+    description: str = ''
+    version: str = ''
+    category: str | None = None
+    organizations: tuple[str, ...] = ()
+    submitter: dict[str, str] | None = None
+    tags: tuple[str, ...] = ()
+    links: tuple[dict, ...] = ()
+    claim_aggregation_strategy: dict = field(
+        default_factory=lambda: dict(DEFAULT_CLAIM_AGGREGATION_STRATEGY)
+    )
+    symbols: dict[str, Symbol] = field(default_factory=dict)
+    claims: dict[str, Claim] = field(default_factory=dict)
+    source_class: type | None = None
+
+    # ------------------------------------------------------------------ graph
+
+    def static_order(self) -> list[str]:
+        """Symbol names in dependency order."""
+        graph = {name: set(sym.dependencies) for name, sym in self.symbols.items()}
+        unknown = {
+            f'{name} -> {dep}'
+            for name, deps in graph.items()
+            for dep in deps
+            if dep not in self.symbols
+        }
+        if unknown:
+            raise ValueError(f'symbols depend on undefined names: {sorted(unknown)}')
+        return list(TopologicalSorter(graph).static_order())
+
+    def sweep_symbols(self) -> list[Symbol]:
+        return [sym for sym in self.symbols.values() if sym.sweep is not None]
+
+    def _sweep_dependent(self) -> set[str]:
+        """
+        Names whose value can change across the sweep.
+
+        Everything else is resolved once and shared. The YAML runner recomputes
+        the whole graph at every sweep point; for a recipe whose first symbol
+        loads a benchmark suite off disk, that is the difference between one
+        load and thirty-two.
+        """
+        dependent = {sym.name for sym in self.sweep_symbols()}
+        # static_order guarantees dependencies precede dependents
+        for name in self.static_order():
+            sym = self.symbols[name]
+            if any(dep in dependent for dep in sym.dependencies):
+                dependent.add(name)
+        return dependent
+
+    # --------------------------------------------------------------- resolve
+
+    def compute(self, name: str, **kwargs) -> Any:
+        """
+        Resolve one symbol from its dependencies.
+
+        Public because the YAML export calls it: an exported card's ``python:``
+        block imports the recipe and calls back here, so the exported card runs
+        the same code the recipe does rather than a transcription of it.
+        """
+        return self.symbols[name].compute(**kwargs)
+
+    def check(self, name: str, **kwargs) -> None:
+        """Run one claim, raising as it would in-process. See :meth:`compute`."""
+        self.claims[name].func(**kwargs)
+
+    def _resolve(self, names: Sequence[str], context: dict) -> tuple[dict, str | None]:
+        """Resolve symbols into a copy of ``context``; return (context, error)."""
+        context = dict(context)
+        for name in names:
+            if name in context:
+                continue
+            sym = self.symbols[name]
+            try:
+                kwargs = {dep: context[dep] for dep in sym.dependencies}
+                context[name] = sym.compute(**kwargs)
+            except Exception as ex:
+                return context, f'ERROR resolving symbol {name!r}: {ex!r}'
+        return context, None
+
+    # -------------------------------------------------------------- evaluate
+
+    def evaluate(self, provenance: bool = True) -> EvaluationResultCard:
+        """
+        Run the recipe and produce a card.
+
+        Resolution failures make a sweep point INCONCLUSIVE rather than raising,
+        matching the YAML runner: a claim that could not be tested is not a
+        claim that was refuted, and the distinction is the whole reason
+        INCONCLUSIVE exists.
+        """
+        order = self.static_order()
+        dependent = self._sweep_dependent()
+        shared_names = [n for n in order if n not in dependent]
+        dynamic_names = [n for n in order if n in dependent]
+
+        shared, error = self._resolve(shared_names, {})
+
+        sweeps = self.sweep_symbols()
+        if sweeps:
+            points = [
+                dict(zip([s.name for s in sweeps], values))
+                for values in product(*[s.sweep for s in sweeps])
+            ]
+        else:
+            points = [{}]
+
+        outcomes: list[ClaimOutcome] = []
+        for point in points:
+            if error is not None:
+                context, point_error = dict(shared, **point), error
+            else:
+                context, point_error = self._resolve(dynamic_names, dict(shared, **point))
+            for name, claim_obj in self.claims.items():
+                if point_error is not None:
+                    outcomes.append(
+                        ClaimOutcome(
+                            claim=name,
+                            verdict=Verdict.INCONCLUSIVE,
+                            message=point_error,
+                            symbols=context,
+                        )
+                    )
+                else:
+                    outcomes.append(claim_obj.evaluate(context))
+
+        verdict = _reduce([o.verdict for o in outcomes], self.claim_aggregation_strategy)
+
+        empirical = EmpiricalResult(
+            verdict=verdict,
+            outcomes=tuple(outcomes),
+            aggregation=dict(self.claim_aggregation_strategy),
+            provenance=EmpiricalResult.default_provenance() if provenance else {},
+        )
+        return EvaluationResultCard(
+            title=self.title,
+            description=self.description,
+            version=self.version,
+            organizations=tuple(self.organizations),
+            tags=tuple(self.tags),
+            recipe=self._qualified_name(),
+            empirical=empirical,
+            theoretical=self.basis(),
+        )
+
+    # ----------------------------------------------------------------- basis
+
+    def basis(self) -> Any | None:
+        """
+        What a card produced from this recipe is standing on, or None.
+
+        Placeholder, and the recipe half of the seam described in
+        :attr:`magnet.card.EvaluationResultCard.theoretical`. Separate work
+        gathers this from annotations on the claim and symbol functions, which
+        is available precisely because they are functions. Until then a card
+        records no basis rather than an empty one, and every other method here
+        behaves the same either way.
+        """
+        return None
+
+    # ---------------------------------------------------------------- export
+
+    def _qualified_name(self) -> str | None:
+        if self.source_class is None:
+            return None
+        return f'{self.source_class.__module__}.{self.source_class.__qualname__}'
+
+    def to_schema_dict(self) -> dict:
+        """
+        Compile to the existing YAML evaluation-card schema.
+
+        Computed symbols become ``python:`` blocks that import this recipe and
+        call back into it. That keeps the export faithful — the emitted card
+        runs the recipe's actual functions rather than a copy of their source —
+        at the cost of requiring the recipe module to be importable wherever the
+        card runs. For a card that already imports a team's predictor package,
+        that costs nothing.
+        """
+        qualname = self._qualified_name()
+        if qualname is None:
+            raise ValueError('recipe has no source class; cannot be exported')
+        module, _, attr = qualname.rpartition('.')
+        preamble = f'from {module} import {attr}'
+
+        symbols: dict[str, Any] = {}
+        for name, sym in self.symbols.items():
+            spec: dict[str, Any] = {}
+            if sym.type:
+                spec['type'] = sym.type
+            metadata = {}
+            if sym.display_name is not None:
+                metadata['display_name'] = sym.display_name
+            if sym.display is not None:
+                metadata['display'] = sym.display
+            if sym.metric is not None:
+                metadata['define_metric'] = sym.metric
+            if metadata:
+                spec['metadata'] = metadata
+
+            if sym.sweep is not None:
+                spec['sweep'] = list(sym.sweep)
+            elif sym.is_computed:
+                if sym.dependencies:
+                    spec['depends_on'] = list(sym.dependencies)
+                args = ', '.join(f'{dep}={dep}' for dep in sym.dependencies)
+                call = f'{attr}.compute({name!r}{", " if args else ""}{args})'
+                spec['python'] = f'{preamble}\n{name} = {call}\n'
+            else:
+                spec['value'] = sym.value
+            symbols[name] = spec
+
+        claim_lines = [preamble]
+        for name, claim_obj in self.claims.items():
+            args = ', '.join(f'{dep}={dep}' for dep in claim_obj.dependencies)
+            claim_lines.append(f'{attr}.check({name!r}{", " if args else ""}{args})')
+
+        out: dict[str, Any] = {
+            'title': self.title,
+            'description': self.description,
+            'version': self.version,
+            'organizations': list(self.organizations),
+            'submitter': self.submitter,
+            'tags': list(self.tags),
+            'links': [dict(link) for link in self.links],
+            'claim': {'python': '\n'.join(claim_lines) + '\n'},
+            'symbols': symbols,
+        }
+        if self.category:
+            out['category'] = self.category
+        if self.claim_aggregation_strategy != DEFAULT_CLAIM_AGGREGATION_STRATEGY:
+            out['claim_aggregation_strategy'] = dict(self.claim_aggregation_strategy)
+        return out
+
+    def to_schema(self):
+        """
+        Validate the export against :class:`magnet.schema.EvaluationCardSchema`.
+
+        Requires a MAGNET that carries the card schema module; older ones
+        validate cards only implicitly, by running them.
+        """
+        try:
+            from magnet.schema import EvaluationCardSchema
+        except ImportError as ex:
+            raise ImportError(
+                'magnet.schema is unavailable in this MAGNET; '
+                'use to_schema_dict() and validate the card by running it'
+            ) from ex
+
+        return EvaluationCardSchema.model_validate(self.to_schema_dict())
+
+    def to_yaml(self) -> str:
+        """Render the compiled card as YAML."""
+        import yaml
+
+        class _Dumper(yaml.SafeDumper):
+            pass
+
+        def _str_representer(dumper, data):
+            # Emit the generated `python:` bodies as literal blocks; an exported
+            # card is meant to be read and reviewed like a written one.
+            style = '|' if '\n' in data else None
+            return dumper.represent_scalar('tag:yaml.org,2002:str', data, style=style)
+
+        _Dumper.add_representer(str, _str_representer)
+        return yaml.dump(self.to_schema_dict(), Dumper=_Dumper, sort_keys=False)
+
+    def write_card(self, path) -> None:
+        """Write the compiled YAML card."""
+        import ubelt as ub
+
+        path = ub.Path(path)
+        path.parent.ensuredir()
+        path.write_text(self.to_yaml())
+
+
+def recipe(
+    title: str = '',
+    description: str = '',
+    version: str = '',
+    category: str | None = None,
+    organizations: Iterable[str] = (),
+    submitter: dict[str, str] | None = None,
+    tags: Iterable[str] = (),
+    links: Iterable[dict] = (),
+    claim_aggregation_strategy: dict | None = None,
+):
+    """
+    Turn a class body into an :class:`EvaluationRecipe`.
+
+    The class is a declaration, not a namespace to instantiate: the decorator
+    reads it and returns the recipe, so the name it was defined under refers to
+    the recipe afterwards.
+
+    Members are read as follows:
+
+    ``@symbol`` function
+        a computed symbol; its parameters are its dependencies
+    ``@claim`` function
+        an assertion over resolved symbols
+    :class:`Sweep` attribute
+        a symbol taking each value in turn
+    any other plain attribute
+        a constant symbol
+
+    Undecorated methods are ignored, so a recipe can keep helpers next to the
+    symbols that use them.
+
+    Example:
+        >>> @recipe(title='Threshold', version='1.0')
+        ... class Simple:
+        ...     threshold = 0.5
+        ...
+        ...     @symbol
+        ...     def score():
+        ...         return 0.25
+        ...
+        ...     @claim
+        ...     def under(score, threshold):
+        ...         assert score < threshold
+        >>> Simple.symbols['threshold'].value
+        0.5
+        >>> Simple.claims['under'].dependencies
+        ('score', 'threshold')
+    """
+
+    def _decorate(cls):
+        symbols: dict[str, Symbol] = {}
+        claims: dict[str, Claim] = {}
+
+        for name, member in vars(cls).items():
+            if name.startswith('_'):
+                continue
+            if isinstance(member, (staticmethod, classmethod)):
+                member = member.__func__
+
+            if callable(member) and hasattr(member, '__magnet_claim__'):
+                meta = member.__magnet_claim__
+                claims[meta['name'] or name] = Claim(
+                    name=meta['name'] or name,
+                    func=member,
+                    dependencies=_parameters(member),
+                )
+            elif callable(member) and hasattr(member, '__magnet_symbol__'):
+                meta = member.__magnet_symbol__
+                symbols[name] = Symbol(
+                    name=name,
+                    func=member,
+                    type=meta['type'],
+                    display_name=meta['display_name'],
+                    display=meta['display'],
+                    metric=meta['metric'],
+                    dependencies=_parameters(member),
+                )
+            elif isinstance(member, Sweep):
+                symbols[name] = Symbol(name=name, sweep=member.values, type=member.type)
+            elif not callable(member):
+                symbols[name] = Symbol(name=name, value=member, type=_type_name(member))
+
+        obj = EvaluationRecipe(
+            title=title or cls.__name__,
+            description=description or (inspect.getdoc(cls) or ''),
+            version=version,
+            category=category,
+            organizations=tuple(organizations),
+            submitter=submitter,
+            tags=tuple(tags),
+            links=tuple(links),
+            claim_aggregation_strategy=(
+                dict(claim_aggregation_strategy)
+                if claim_aggregation_strategy
+                else dict(DEFAULT_CLAIM_AGGREGATION_STRATEGY)
+            ),
+            symbols=symbols,
+            claims=claims,
+            source_class=cls,
+        )
+        obj.static_order()  # fail at definition time on a bad graph, not at run time
+        return obj
+
+    return _decorate
+
+
+def _parameters(func: Callable) -> tuple[str, ...]:
+    """Positional parameter names, which are a function's symbol dependencies."""
+    signature = inspect.signature(func)
+    return tuple(
+        name
+        for name, param in signature.parameters.items()
+        if param.kind
+        in (inspect.Parameter.POSITIONAL_ONLY, inspect.Parameter.POSITIONAL_OR_KEYWORD)
+    )
+
+
+def _type_name(value: Any) -> str | None:
+    if isinstance(value, bool):
+        return 'bool'
+    if isinstance(value, (int, float, str)):
+        return type(value).__name__
+    return None
+
+
+def _reduce(verdicts: Sequence[Verdict], strategy: dict) -> Verdict:
+    """
+    Reduce per-sweep-point verdicts to one card-level verdict.
+
+    Mirrors ``magnet.evaluation._reduce_results``; ``tests/test_recipe.py``
+    asserts the two agree, since a recipe and its exported YAML card giving
+    different answers would be worse than either being wrong.
+    """
+    total = len(verdicts)
+    if total == 0:
+        return Verdict.INCONCLUSIVE
+
+    verified = sum(v is Verdict.VERIFIED for v in verdicts)
+    falsified = sum(v is Verdict.FALSIFIED for v in verdicts)
+    inconclusive = sum(v is Verdict.INCONCLUSIVE for v in verdicts)
+
+    kind = strategy.get('type', 'all')
+    if kind == 'all':
+        if falsified:
+            return Verdict.FALSIFIED
+        if inconclusive:
+            return Verdict.INCONCLUSIVE
+        return Verdict.VERIFIED
+    if kind == 'any':
+        if verified:
+            return Verdict.VERIFIED
+        if inconclusive:
+            return Verdict.INCONCLUSIVE
+        return Verdict.FALSIFIED
+    if kind == 'fraction':
+        threshold = (strategy.get('parameters') or {}).get('threshold')
+        if threshold is None:
+            raise ValueError('reduce type=fraction requires `threshold`')
+        return Verdict.VERIFIED if verified / total >= threshold else Verdict.FALSIFIED
+    raise ValueError(f'Unknown reduce type: {kind!r}')

--- a/tests/test_recipe.py
+++ b/tests/test_recipe.py
@@ -1,0 +1,283 @@
+"""
+Tests for Python-defined evaluation recipes.
+
+Two properties matter most. A recipe and the YAML card it compiles to must
+agree, or the export is worse than not having one. And the verdict mapping must
+match the YAML runner's, because FALSIFIED (tested and false) and INCONCLUSIVE
+(never actually tested) are not interchangeable.
+"""
+import pytest
+
+from magnet.card import Verdict
+from magnet.recipe import Sweep, _reduce, claim, recipe, symbol
+
+
+def test_constants_sweeps_and_computed_symbols():
+    @recipe(title='Basic', version='1.0')
+    class Basic:
+        offset = 2
+        base = Sweep([1, 2, 3])
+
+        @symbol(type='int')
+        def total(base, offset):
+            return base + offset
+
+        @claim
+        def positive(total):
+            assert total > 0
+
+    assert Basic.symbols['offset'].value == 2
+    assert Basic.symbols['base'].sweep == (1, 2, 3)
+    assert Basic.symbols['total'].dependencies == ('base', 'offset')
+    assert Basic.claims['positive'].dependencies == ('total',)
+
+
+def test_helpers_are_not_symbols():
+    @recipe(title='Helpers')
+    class WithHelper:
+        def helper(x):
+            return x
+
+        @symbol
+        def value():
+            return 1
+
+        @claim
+        def ok(value):
+            assert value == 1
+
+    assert set(WithHelper.symbols) == {'value'}
+
+
+def test_undefined_dependency_fails_at_definition_time():
+    with pytest.raises(ValueError, match='undefined names'):
+
+        @recipe(title='Broken')
+        class Broken:
+            @symbol
+            def a(does_not_exist):
+                return does_not_exist
+
+            @claim
+            def ok(a):
+                assert a
+
+
+def test_sweep_produces_one_outcome_per_point():
+    @recipe(title='Sweeps')
+    class Sweeps:
+        a = Sweep([1, 2])
+        b = Sweep([10, 20, 30])
+
+        @claim
+        def ok(a, b):
+            assert a < b
+
+    card = Sweeps.evaluate()
+    assert len(card.empirical.outcomes) == 6
+    assert card.verdict is Verdict.VERIFIED
+
+
+def test_assertion_failure_is_falsified_and_carries_the_message():
+    @recipe(title='Falsify')
+    class Falsify:
+        @claim
+        def ok():
+            assert False, 'the number was wrong'
+
+    card = Falsify.evaluate()
+    assert card.verdict is Verdict.FALSIFIED
+    assert 'the number was wrong' in card.empirical.outcomes[0].message
+
+
+def test_other_exceptions_are_inconclusive_not_falsified():
+    # A claim that blew up was never tested. Reporting it as FALSIFIED would
+    # assert something about the world that the run did not establish.
+    @recipe(title='Blows up')
+    class BlowsUp:
+        @claim
+        def ok():
+            raise RuntimeError('the endpoint was down')
+
+    card = BlowsUp.evaluate()
+    assert card.verdict is Verdict.INCONCLUSIVE
+    assert 'endpoint was down' in card.empirical.outcomes[0].message
+
+
+def test_symbol_resolution_failure_is_inconclusive():
+    @recipe(title='Bad symbol')
+    class BadSymbol:
+        @symbol
+        def broken():
+            raise ValueError('no data on disk')
+
+        @claim
+        def ok(broken):
+            assert broken
+
+    card = BadSymbol.evaluate()
+    assert card.verdict is Verdict.INCONCLUSIVE
+    assert 'no data on disk' in card.empirical.outcomes[0].message
+
+
+def test_symbols_outside_the_sweep_are_computed_once():
+    # Not a micro-optimisation: the leading symbol of a real card loads a
+    # benchmark suite off disk, and the sweep runs dozens of points.
+    calls = {'expensive': 0, 'cheap': 0}
+
+    @recipe(title='Sharing')
+    class Sharing:
+        seed = Sweep([1, 2, 3, 4])
+
+        @symbol
+        def expensive():
+            calls['expensive'] += 1
+            return 100
+
+        @symbol
+        def cheap(expensive, seed):
+            calls['cheap'] += 1
+            return expensive + seed
+
+        @claim
+        def ok(cheap):
+            assert cheap > 0
+
+    Sharing.evaluate()
+    assert calls['expensive'] == 1
+    assert calls['cheap'] == 4
+
+
+def test_fraction_aggregation():
+    @recipe(
+        title='Fraction',
+        claim_aggregation_strategy={'type': 'fraction', 'parameters': {'threshold': 0.5}},
+    )
+    class Fraction:
+        value = Sweep([1, 2, 3, 4])
+
+        @claim
+        def small(value):
+            assert value <= 2
+
+    card = Fraction.evaluate()
+    assert card.empirical.counts == {'VERIFIED': 2, 'FALSIFIED': 2}
+    assert card.verdict is Verdict.VERIFIED  # 2/4 >= 0.5
+
+
+@pytest.mark.parametrize(
+    'strategy',
+    [
+        {'type': 'all'},
+        {'type': 'any'},
+        {'type': 'fraction', 'parameters': {'threshold': 0.8}},
+        {'type': 'fraction', 'parameters': {'threshold': 0.2}},
+    ],
+)
+@pytest.mark.parametrize(
+    'verdicts',
+    [
+        ['VERIFIED'],
+        ['FALSIFIED'],
+        ['INCONCLUSIVE'],
+        ['VERIFIED', 'FALSIFIED'],
+        ['VERIFIED', 'INCONCLUSIVE'],
+        ['VERIFIED', 'VERIFIED', 'VERIFIED', 'FALSIFIED'],
+        ['FALSIFIED', 'INCONCLUSIVE'],
+    ],
+)
+def test_reduce_agrees_with_the_yaml_runner(strategy, verdicts):
+    # A recipe and its exported card disagreeing about the verdict would be
+    # worse than either of them being wrong.
+    from magnet.evaluation import _reduce_results
+
+    ours = _reduce([Verdict(v) for v in verdicts], strategy)
+    theirs = _reduce_results(list(verdicts), strategy)
+    assert str(ours) == theirs
+
+
+def test_export_compiles_to_a_runnable_card():
+    from magnet.examples.commutative_arithmetic import CommutativeAddition
+
+    spec = CommutativeAddition.to_schema_dict()
+    assert spec['title'] == 'Arithmetic - Addition Commutative Property'
+    assert spec['category'] == 'Mathematical Properties'
+    assert spec['symbols']['int_range_even']['type'] == 'List[int]'
+    assert (
+        spec['symbols']['int_range_even']['metadata']['display_name']
+        == 'Set of Even Numbers'
+    )
+
+    # Computed symbols call back into the recipe rather than duplicating source,
+    # so the exported card runs the same code the recipe does.
+    body = spec['symbols']['int_range_odd']['python']
+    assert 'from magnet.examples.commutative_arithmetic import CommutativeAddition' in body
+    assert "CommutativeAddition.compute('int_range_odd', int_range_even=int_range_even)" in body
+    assert spec['symbols']['int_range_odd']['depends_on'] == ['int_range_even']
+
+
+def test_export_carries_sweeps_and_aggregation():
+    @recipe(
+        title='Swept',
+        claim_aggregation_strategy={'type': 'fraction', 'parameters': {'threshold': 0.8}},
+    )
+    class Swept:
+        seed = Sweep([1, 2, 3, 4, 5])
+        sample_size = 16
+
+        @claim
+        def positive(seed, sample_size):
+            assert seed * sample_size > 0
+
+    spec = Swept.to_schema_dict()
+    assert spec['claim_aggregation_strategy']['parameters']['threshold'] == 0.8
+    assert spec['symbols']['seed']['sweep'] == [1, 2, 3, 4, 5]
+    assert spec['symbols']['sample_size']['value'] == 16
+
+
+def test_exported_python_blocks_execute_like_the_recipe():
+    from magnet.examples.commutative_arithmetic import CommutativeAddition
+
+    spec = CommutativeAddition.to_schema_dict()
+    context = {'int_range_even': [0, 2, 4]}
+    exec(spec['symbols']['int_range_odd']['python'], context)
+    assert context['int_range_odd'] == [1, 3, 5]
+
+
+def test_export_validates_against_the_card_schema():
+    from magnet.examples.commutative_arithmetic import CommutativeAddition
+
+    # A recipe that compiles to something the schema rejects would not be an
+    # export at all.
+    CommutativeAddition.to_schema()
+
+
+def test_the_yaml_runner_agrees_with_the_recipe(tmp_path):
+    # The claim this whole layer rests on: a recipe and the card it compiles to
+    # are the same evaluation. Checked against the real runner, not a model of
+    # it -- the exported YAML is loaded and executed by
+    # `magnet.evaluation.EvaluationCard`, which knows nothing about recipes.
+    from magnet.evaluation import EvaluationCard
+    from magnet.examples.commutative_arithmetic import CommutativeAddition
+
+    card_path = tmp_path / 'commutative.yaml'
+    CommutativeAddition.write_card(card_path)
+
+    theirs = EvaluationCard(card_path, tmp_path / 'results').evaluate()
+    ours = CommutativeAddition.evaluate()
+
+    assert str(ours.verdict) == theirs == 'VERIFIED'
+
+
+def test_a_card_with_no_basis_says_so():
+    @recipe(title='Ungrounded')
+    class Ungrounded:
+        @claim
+        def ok():
+            assert True
+
+    card = Ungrounded.evaluate()
+    # The slot is present and empty rather than absent, so a reader can tell
+    # "nothing recorded" from "nothing to record".
+    assert card.theoretical is None
+    assert 'BASIS:   not recorded' in card.render()


### PR DESCRIPTION
Claude Description: 

> MAGNET calls one object the evaluation card, and it is three things at once: the YAML program, the runner that executes it, and the result. So "the card sweeps five thresholds" and "the card said VERIFIED" are sentences about the same object, and a result cannot be written, diffed or archived without dragging the runner along.
> 
> This splits them. An `EvaluationRecipe` is the authored program -- symbols, sweeps and a claim, written as decorated functions rather than `python:` strings, with dependencies read from signatures instead of a `depends_on` list that can silently disagree with the code beneath it. Running one produces an `EvaluationResultCard`: verdict, per-sweep outcomes, provenance, and a slot for what the verdict is standing on.
> 
> That slot is a placeholder here. `EvaluationResultCard.theoretical` is typed loosely, rendered by `_basis_lines` as "not recorded", and produced by `EvaluationRecipe.basis` returning None. Separate work fills all three in; the structure can be judged without it, and this branch depends on nothing but main.
> 
> Neither name is taken. `magnet.evaluation.EvaluationCard` is still the loaded YAML program and its runner, untouched, and recipes compile back to the existing schema via `to_schema_dict`, so nothing here forks the runner or the format. A team that writes YAML is unaffected.
> 
> `examples/commutative_arithmetic.py` is `cards/simple.yaml` written as a recipe, a line-for-line port meant to be read beside it. The test that matters is `test_the_yaml_runner_agrees_with_the_recipe`: it compiles the recipe to YAML, hands it to the real `EvaluationCard`, and checks the two verdicts agree.