### PR TITLE
Accept `depends` as a spelling of `depends_on`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,11 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
-* Evaluation card symbols may declare dependencies as either `depends_on` or
-  `depends`. Only the former was read, so the latter was silently dropped and
-  resolution order fell back to declaration order in the YAML.
+* Accept `depends` as an alias for `depends_on` in symbol dependencies.
 
 ### Changed
 
-* `magnet evaluate` now warns when a symbol spec contains an unrecognized key,
-  instead of ignoring it silently.
+* Warn on unrecognized symbol-spec keys.
 
 ## Version 0.0.2 -- Released 2026-05-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,19 @@
 This changelog follows the specifications detailed in: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html), although we have not yet reached a `1.0.0` release.
 
+## Unreleased
+
+### Fixed
+
+* Evaluation card symbols may declare dependencies as either `depends_on` or
+  `depends`. Only the former was read, so the latter was silently dropped and
+  resolution order fell back to declaration order in the YAML.
+
+### Changed
+
+* `magnet evaluate` now warns when a symbol spec contains an unrecognized key,
+  instead of ignoring it silently.
+
 ## Version 0.0.2 -- Released 2026-05-08
 
 ### Added

--- a/magnet/evaluation.py
+++ b/magnet/evaluation.py
@@ -841,7 +841,27 @@ class Symbol:
         >>> x = Symbol('x', {'type': "List[int]", 'python': "x = [10]"})
         >>> x.eval()
         [10]
+
+    Example:
+        >>> # `depends` is accepted as a spelling of `depends_on`.
+        >>> from magnet.evaluation import Symbol
+        >>> spec = {'type': 'int', 'python': 'y = x + 1', 'depends': ['x']}
+        >>> Symbol('y', spec).dependencies
+        ['x']
     """
+
+    #: Keys a symbol spec may declare.
+    #:
+    #: ``depends`` is an accepted spelling of ``depends_on``.  Cards are
+    #: hand-written YAML and both spellings are in use; the wrong one used to
+    #: be dropped by ``dict.get``, which left the symbol with no declared
+    #: dependencies at all.  That is silent and order-dependent -- see
+    #: :meth:`Symbols._construct_dependency_order` -- so accept both rather
+    #: than let a card claim a dependency the resolver never sees.
+    KNOWN_SPEC_KEYS = frozenset({
+        'type', 'value', 'sweep', 'python', 'depends_on', 'depends',
+        'metadata',
+    })
 
     def __init__(self, name: str, spec: Dict[str, Any]) -> None:
         self.name = name
@@ -849,8 +869,74 @@ class Symbol:
         self.sweep = spec.get('sweep')
         self.type = spec.get('type', 'List[int]')
         self.definition = spec.get('python', '')
-        self.dependencies = spec.get('depends_on', [])
+        self.dependencies = self._resolve_dependencies(name, spec)
         self.metadata = spec.get('metadata')
+
+        unknown = set(spec) - self.KNOWN_SPEC_KEYS
+        if unknown:
+            # Not fatal: an unrecognized key may be forward-compatible or
+            # simply decorative.  But it is never *acted on*, so say so --
+            # a misspelling here is otherwise indistinguishable from a key
+            # that was honored.
+            logger.warning(
+                f'symbol {name!r}: ignoring unrecognized key(s) '
+                f'{sorted(unknown)}; recognized keys are '
+                f'{sorted(self.KNOWN_SPEC_KEYS)}'
+            )
+
+    @staticmethod
+    def _resolve_dependencies(
+        name: str, spec: Dict[str, Any]
+    ) -> List[str]:
+        """
+        Read declared dependencies under either accepted spelling.
+
+        Args:
+            name (str): the symbol's name, for error messages.
+            spec (Dict[str, Any]): the symbol spec as written in the card.
+
+        Returns:
+            List[str]: the declared dependencies, possibly empty.
+
+        Raises:
+            ValueError: if both spellings are present and disagree.
+
+        Example:
+            >>> from magnet.evaluation import Symbol
+            >>> Symbol._resolve_dependencies('y', {'depends_on': ['x']})
+            ['x']
+            >>> Symbol._resolve_dependencies('y', {'depends': ['x']})
+            ['x']
+            >>> Symbol._resolve_dependencies('y', {})
+            []
+            >>> # Both spellings agreeing is redundant but harmless.
+            >>> Symbol._resolve_dependencies(
+            ...     'y', {'depends': ['x'], 'depends_on': ['x']})
+            ['x']
+            >>> # Both spellings disagreeing has no defensible reading.
+            >>> Symbol._resolve_dependencies(
+            ...     'y', {'depends': ['x'], 'depends_on': ['z']})
+            Traceback (most recent call last):
+                ...
+            ValueError: symbol 'y' declares both `depends_on` (['z']) and ...
+        """
+        canonical = spec.get('depends_on')
+        alias = spec.get('depends')
+
+        if canonical is not None and alias is not None:
+            if list(canonical) != list(alias):
+                raise ValueError(
+                    f'symbol {name!r} declares both `depends_on` '
+                    f'({canonical!r}) and `depends` ({alias!r}), and they '
+                    f'disagree. They are the same key; give one of them.'
+                )
+            return list(canonical)
+
+        if canonical is not None:
+            return list(canonical)
+        if alias is not None:
+            return list(alias)
+        return []
 
     def eval(self, context: Dict[str, Any] = {}) -> Any:
         """
@@ -928,6 +1014,23 @@ class Symbols:
         >>> symbols.resolve()
         >>> symbols()
         {'x': [10]}
+
+    Example:
+        >>> # A declared dependency orders resolution, so a card is free to
+        >>> # write its symbols in any order.  Here the dependent symbol is
+        >>> # declared FIRST, which without the edge would exec `y = x + 1`
+        >>> # against a context that has no `x` yet.
+        >>> from magnet.evaluation import Symbols
+        >>> for spelling in ['depends_on', 'depends']:
+        ...     symbols = Symbols({
+        ...         'y': {'type': 'int', 'python': 'y = x + 1',
+        ...               spelling: ['x']},
+        ...         'x': {'type': 'int', 'value': 1},
+        ...     })
+        ...     symbols.resolve()
+        ...     print(f'{spelling}: {symbols()}')
+        depends_on: {'y': 2, 'x': 1}
+        depends: {'y': 2, 'x': 1}
     """
 
     def __init__(self, symbol_specs: Dict[str, Any]) -> None:

--- a/magnet/evaluation.py
+++ b/magnet/evaluation.py
@@ -397,7 +397,6 @@ class EvaluationCard:
 
         self.claim.status = card_result
         return card_result
-
     def dispatch(
         self, flattened_sweep: List['Symbols']
     ) -> List['EvaluationTask']:
@@ -841,23 +840,8 @@ class Symbol:
         >>> x = Symbol('x', {'type': "List[int]", 'python': "x = [10]"})
         >>> x.eval()
         [10]
-
-    Example:
-        >>> # `depends` is accepted as a spelling of `depends_on`.
-        >>> from magnet.evaluation import Symbol
-        >>> spec = {'type': 'int', 'python': 'y = x + 1', 'depends': ['x']}
-        >>> Symbol('y', spec).dependencies
-        ['x']
     """
 
-    #: Keys a symbol spec may declare.
-    #:
-    #: ``depends`` is an accepted spelling of ``depends_on``.  Cards are
-    #: hand-written YAML and both spellings are in use; the wrong one used to
-    #: be dropped by ``dict.get``, which left the symbol with no declared
-    #: dependencies at all.  That is silent and order-dependent -- see
-    #: :meth:`Symbols._construct_dependency_order` -- so accept both rather
-    #: than let a card claim a dependency the resolver never sees.
     KNOWN_SPEC_KEYS = frozenset({
         'type', 'value', 'sweep', 'python', 'depends_on', 'depends',
         'metadata',
@@ -874,14 +858,8 @@ class Symbol:
 
         unknown = set(spec) - self.KNOWN_SPEC_KEYS
         if unknown:
-            # Not fatal: an unrecognized key may be forward-compatible or
-            # simply decorative.  But it is never *acted on*, so say so --
-            # a misspelling here is otherwise indistinguishable from a key
-            # that was honored.
             logger.warning(
-                f'symbol {name!r}: ignoring unrecognized key(s) '
-                f'{sorted(unknown)}; recognized keys are '
-                f'{sorted(self.KNOWN_SPEC_KEYS)}'
+                f'symbol {name!r}: unrecognized key(s): {sorted(unknown)}'
             )
 
     @staticmethod
@@ -889,54 +867,36 @@ class Symbol:
         name: str, spec: Dict[str, Any]
     ) -> List[str]:
         """
-        Read declared dependencies under either accepted spelling.
+        Read dependencies from `depends_on` or its `depends` alias.
 
         Args:
-            name (str): the symbol's name, for error messages.
-            spec (Dict[str, Any]): the symbol spec as written in the card.
+            name: Symbol name used in error messages.
+            spec: Symbol specification.
 
         Returns:
-            List[str]: the declared dependencies, possibly empty.
+            Declared dependency names.
 
         Raises:
-            ValueError: if both spellings are present and disagree.
+            ValueError: If both spellings are present and disagree.
 
         Example:
-            >>> from magnet.evaluation import Symbol
-            >>> Symbol._resolve_dependencies('y', {'depends_on': ['x']})
-            ['x']
             >>> Symbol._resolve_dependencies('y', {'depends': ['x']})
             ['x']
-            >>> Symbol._resolve_dependencies('y', {})
-            []
-            >>> # Both spellings agreeing is redundant but harmless.
-            >>> Symbol._resolve_dependencies(
-            ...     'y', {'depends': ['x'], 'depends_on': ['x']})
-            ['x']
-            >>> # Both spellings disagreeing has no defensible reading.
-            >>> Symbol._resolve_dependencies(
-            ...     'y', {'depends': ['x'], 'depends_on': ['z']})
-            Traceback (most recent call last):
-                ...
-            ValueError: symbol 'y' declares both `depends_on` (['z']) and ...
         """
         canonical = spec.get('depends_on')
         alias = spec.get('depends')
 
-        if canonical is not None and alias is not None:
-            if list(canonical) != list(alias):
-                raise ValueError(
-                    f'symbol {name!r} declares both `depends_on` '
-                    f'({canonical!r}) and `depends` ({alias!r}), and they '
-                    f'disagree. They are the same key; give one of them.'
-                )
-            return list(canonical)
+        if (
+            canonical is not None
+            and alias is not None
+            and list(canonical) != list(alias)
+        ):
+            raise ValueError(
+                f'symbol {name!r}: `depends_on` and `depends` disagree'
+            )
 
-        if canonical is not None:
-            return list(canonical)
-        if alias is not None:
-            return list(alias)
-        return []
+        dependencies = canonical if canonical is not None else alias
+        return [] if dependencies is None else list(dependencies)
 
     def eval(self, context: Dict[str, Any] = {}) -> Any:
         """
@@ -1014,23 +974,6 @@ class Symbols:
         >>> symbols.resolve()
         >>> symbols()
         {'x': [10]}
-
-    Example:
-        >>> # A declared dependency orders resolution, so a card is free to
-        >>> # write its symbols in any order.  Here the dependent symbol is
-        >>> # declared FIRST, which without the edge would exec `y = x + 1`
-        >>> # against a context that has no `x` yet.
-        >>> from magnet.evaluation import Symbols
-        >>> for spelling in ['depends_on', 'depends']:
-        ...     symbols = Symbols({
-        ...         'y': {'type': 'int', 'python': 'y = x + 1',
-        ...               spelling: ['x']},
-        ...         'x': {'type': 'int', 'value': 1},
-        ...     })
-        ...     symbols.resolve()
-        ...     print(f'{spelling}: {symbols()}')
-        depends_on: {'y': 2, 'x': 1}
-        depends: {'y': 2, 'x': 1}
     """
 
     def __init__(self, symbol_specs: Dict[str, Any]) -> None:

--- a/magnet/schema.py
+++ b/magnet/schema.py
@@ -36,8 +36,7 @@ class SymbolSchema(BaseModel):
     type: str | None = None
     value: Any | None = None
     sweep: list | None = None
-    # `depends` is an accepted spelling of `depends_on`; both are in use in
-    # hand-written cards. See magnet.evaluation.Symbol.KNOWN_SPEC_KEYS.
+    # `depends` is an alias for `depends_on`.
     # TODO: modify "depends_on" to reference an actual symbol
     depends_on: list[str] = Field(
         default_factory=list,
@@ -52,11 +51,12 @@ class SymbolSchema(BaseModel):
         if isinstance(data, dict):
             depends_on = data.get('depends_on')
             depends = data.get('depends')
-            if depends_on is not None and depends is not None:
-                if list(depends_on) != list(depends):
-                    raise ValueError(
-                        '`depends_on` and `depends` are aliases and must agree'
-                    )
+            if (
+                depends_on is not None
+                and depends is not None
+                and depends_on != depends
+            ):
+                raise ValueError('`depends_on` and `depends` must agree')
         return data
 
     @model_validator(mode='after')

--- a/magnet/schema.py
+++ b/magnet/schema.py
@@ -1,6 +1,6 @@
 from enum import StrEnum
 from typing import Any, Literal, Optional
-from pydantic import BaseModel, Field, model_validator
+from pydantic import AliasChoices, BaseModel, Field, model_validator
 
 class LinkSchema(BaseModel):
     title: str
@@ -36,7 +36,13 @@ class SymbolSchema(BaseModel):
     type: str | None = None
     value: Any | None = None
     sweep: list | None = None
-    depends_on: list[str] = Field(default_factory=list) # TODO: modify "depends_on" to reference an actual symbol
+    # `depends` is an accepted spelling of `depends_on`; both are in use in
+    # hand-written cards. See magnet.evaluation.Symbol.KNOWN_SPEC_KEYS.
+    # TODO: modify "depends_on" to reference an actual symbol
+    depends_on: list[str] = Field(
+        default_factory=list,
+        validation_alias=AliasChoices('depends_on', 'depends'),
+    )
     python: str | None = None # TODO: this can be validated with a syntax check
     metadata: SymbolMetadataSchema | None = None
 

--- a/magnet/schema.py
+++ b/magnet/schema.py
@@ -46,6 +46,19 @@ class SymbolSchema(BaseModel):
     python: str | None = None # TODO: this can be validated with a syntax check
     metadata: SymbolMetadataSchema | None = None
 
+    @model_validator(mode='before')
+    @classmethod
+    def dependency_aliases_agree(cls, data: Any) -> Any:
+        if isinstance(data, dict):
+            depends_on = data.get('depends_on')
+            depends = data.get('depends')
+            if depends_on is not None and depends is not None:
+                if list(depends_on) != list(depends):
+                    raise ValueError(
+                        '`depends_on` and `depends` are aliases and must agree'
+                    )
+        return data
+
     @model_validator(mode='after')
     def has_resolution(self) -> 'SymbolSchema':
         if self.value is None and self.sweep is None and self.python is None:

--- a/magnet/schema.py
+++ b/magnet/schema.py
@@ -48,6 +48,9 @@ class SymbolSchema(BaseModel):
     @model_validator(mode='before')
     @classmethod
     def dependency_aliases_agree(cls, data: Any) -> Any:
+        """
+        Error both depends_on and depends are given and they disagree.
+        """
         if isinstance(data, dict):
             depends_on = data.get('depends_on')
             depends = data.get('depends')
@@ -63,7 +66,7 @@ class SymbolSchema(BaseModel):
     def has_resolution(self) -> 'SymbolSchema':
         if self.value is None and self.sweep is None and self.python is None:
             if self.metadata is not None and self.metadata.define_metric is not None:
-                # Handle metric definitions in kwdagger/pipeline cards 
+                # Handle metric definitions in kwdagger/pipeline cards
                 # (i.e. ignore test for symbols defined/calculated in user script)
                 return self
             else:

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -104,6 +104,9 @@ def test_parallel_evaluation_preserves_metrics(tmp_path):
 
 @pytest.mark.parametrize('dependency_key', ['depends_on', 'depends'])
 def test_symbol_dependency_alias_orders_resolution(dependency_key):
+    """
+    Check that symbol are ordered topologically by the dependency graph.
+    """
     symbols = Symbols({
         'y': {
             'type': 'int',

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -1,6 +1,8 @@
 import json
 
-from magnet.evaluation import EvaluationCard
+import pytest
+
+from magnet.evaluation import EvaluationCard, Symbol, Symbols
 
 
 TEST_CARD_TEXT = """
@@ -25,6 +27,7 @@ symbols:
     python: |
       score = x
 """
+
 
 def test_evaluation_preserves_metrics(tmp_path):
     card_fpath = tmp_path / 'card.yaml'
@@ -97,3 +100,27 @@ def test_parallel_evaluation_preserves_metrics(tmp_path):
             / claim_hash
             / 'verdict.json'
         ).exists()
+
+
+@pytest.mark.parametrize('dependency_key', ['depends_on', 'depends'])
+def test_symbol_dependency_alias_orders_resolution(dependency_key):
+    symbols = Symbols({
+        'y': {
+            'type': 'int',
+            'python': 'y = x + 1',
+            dependency_key: ['x'],
+        },
+        'x': {'type': 'int', 'value': 1},
+    })
+
+    symbols.resolve()
+
+    assert symbols()['y'] == 2
+
+
+def test_symbol_dependency_aliases_must_agree():
+    with pytest.raises(
+        ValueError,
+        match='`depends_on` and `depends` disagree',
+    ):
+        Symbol('y', {'depends_on': ['x'], 'depends': ['z']})

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -115,6 +115,6 @@ def test_symbol_dependency_aliases_must_not_disagree(simple_card):
     }
     with pytest.raises(
         ValidationError,
-        match='`depends_on` and `depends` are aliases and must agree',
+        match='`depends_on` and `depends` must agree',
     ):
         EvaluationCardSchema.model_validate(card)

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -66,3 +66,55 @@ def test_custom_metric_strategy_still_validates(simple_card):
         },
     }
     EvaluationCardSchema.model_validate(card)
+
+
+@pytest.mark.parametrize('dependency_key', ['depends_on', 'depends'])
+def test_symbol_dependency_aliases_validate(simple_card, dependency_key):
+    card = {
+        **simple_card,
+        'symbols': {
+            'x': {'value': 1},
+            'y': {
+                'python': 'y = x + 1',
+                dependency_key: ['x'],
+            },
+        },
+    }
+    validated = EvaluationCardSchema.model_validate(card)
+    assert validated.symbols['y'].depends_on == ['x']
+
+
+def test_symbol_dependency_aliases_may_agree(simple_card):
+    card = {
+        **simple_card,
+        'symbols': {
+            'x': {'value': 1},
+            'y': {
+                'python': 'y = x + 1',
+                'depends_on': ['x'],
+                'depends': ['x'],
+            },
+        },
+    }
+    validated = EvaluationCardSchema.model_validate(card)
+    assert validated.symbols['y'].depends_on == ['x']
+
+
+def test_symbol_dependency_aliases_must_not_disagree(simple_card):
+    card = {
+        **simple_card,
+        'symbols': {
+            'x': {'value': 1},
+            'z': {'value': 2},
+            'y': {
+                'python': 'y = x + 1',
+                'depends_on': ['x'],
+                'depends': ['z'],
+            },
+        },
+    }
+    with pytest.raises(
+        ValidationError,
+        match='`depends_on` and `depends` are aliases and must agree',
+    ):
+        EvaluationCardSchema.model_validate(card)


### PR DESCRIPTION
It seems like UMD and SRI cards are specifying "depends" in their cards instead of "depends_on", which means the dependency structure of the cards isn't encoded and happens to work because the dependencies are simple and symbols are specified in the right order. This PR makes "depends" an alias of "depends_on" to support both. 

The short version is:

Existing cards that semantically had symbol dependencies (via "depends") were being ignored. Now depends is an alias of "depends_on", so if teams keep using the same name and reorder the symbols, the symbols will resolve correctly. 

The long version from Claude is: 

> A symbol spec's dependencies were read with `spec.get('depends_on', [])`, so a card that wrote `depends` got an empty list. Nothing reported it: the dependency graph simply had no edges, and resolution order fell back to the order the symbols happen to be declared in the YAML.
> 
> That is silent and positional. A card whose dependent symbol is declared before the symbol it needs fails with a NameError raised from inside `exec`, naming a symbol the card visibly declares a dependency on. Cards that work today do so because their declaration order happens to agree with their dependency order, which nothing checks or maintains.
> 
> Both spellings are in use across the cards on hand, and the short one is the more common of the two, so accept either rather than treat the more popular spelling as a typo. Declaring both is fine when they agree and an error when they disagree, since a disagreement has no defensible reading.
> 
> Also warn on unrecognized keys in a symbol spec. The bug above was invisible precisely because an ignored key looks exactly like an honored one. A survey of the cards on hand turned up no unrecognized keys at all, so this should stay quiet until something is genuinely wrong.